### PR TITLE
Triggers case-insensitve changes on Windows

### DIFF
--- a/lib/DirectoryWatcher.js
+++ b/lib/DirectoryWatcher.js
@@ -12,6 +12,11 @@ var watcherManager = require("./watcherManager");
 
 var FS_ACCURENCY = 10000;
 
+var isWindows = process.platform === 'win32';
+
+function formatPath(path) {
+	return isWindows ? path.toLowerCase() : path;
+}
 
 function DirectoryWatcher(path, options) {
 	EventEmitter.call(this);
@@ -50,8 +55,8 @@ DirectoryWatcher.prototype.setFileTime = function setFileTime(path, mtime, initi
 	this.files[path] = [initial ? Math.min(now, mtime) : now, mtime];
 	if(!old) {
 		if(mtime) {
-			if(this.watchers[path]) {
-				this.watchers[path].forEach(function(w) {
+			if(this.watchers[formatPath(path)]) {
+				this.watchers[formatPath(path)].forEach(function(w) {
 					if(!initial || w.checkStartTime(mtime, initial)) {
 						w.emit("change", mtime);
 					}
@@ -59,20 +64,20 @@ DirectoryWatcher.prototype.setFileTime = function setFileTime(path, mtime, initi
 			}
 		}
 	} else if(!initial && mtime && type !== "add") {
-		if(this.watchers[path]) {
-			this.watchers[path].forEach(function(w) {
+		if(this.watchers[formatPath(path)]) {
+			this.watchers[formatPath(path)].forEach(function(w) {
 				w.emit("change", mtime);
 			});
 		}
 	} else if(!initial && !mtime) {
-		if(this.watchers[path]) {
-			this.watchers[path].forEach(function(w) {
+		if(this.watchers[formatPath(path)]) {
+			this.watchers[formatPath(path)].forEach(function(w) {
 				w.emit("remove");
 			});
 		}
 	}
-	if(this.watchers[this.path]) {
-		this.watchers[this.path].forEach(function(w) {
+	if(this.watchers[formatPath(this.path)]) {
+		this.watchers[formatPath(this.path)].forEach(function(w) {
 			if(!initial || w.checkStartTime(mtime, initial)) {
 				w.emit("change", path, mtime);
 			}
@@ -95,8 +100,8 @@ DirectoryWatcher.prototype.setDirectory = function setDirectory(path, exist, ini
 			if(this.nestedWatching)
 				this.directories[path].close();
 			delete this.directories[path];
-			if(!initial && this.watchers[this.path]) {
-				this.watchers[this.path].forEach(function(w) {
+			if(!initial && this.watchers[formatPath(this.path)]) {
+				this.watchers[formatPath(this.path)].forEach(function(w) {
 					w.emit("change", path, w.data);
 				});
 			}
@@ -107,8 +112,8 @@ DirectoryWatcher.prototype.setDirectory = function setDirectory(path, exist, ini
 DirectoryWatcher.prototype.createNestedWatcher = function(path) {
 	this.directories[path] = watcherManager.watchDirectory(path, 1);
 	this.directories[path].on("change", function(path, mtime) {
-		if(this.watchers[this.path]) {
-			this.watchers[this.path].forEach(function(w) {
+		if(this.watchers[formatPath(this.path)]) {
+			this.watchers[formatPath(this.path)].forEach(function(w) {
 				if(w.checkStartTime(mtime, false)) {
 					w.emit("change", path, mtime);
 				}
@@ -134,21 +139,21 @@ DirectoryWatcher.prototype.setNestedWatching = function(flag) {
 };
 
 DirectoryWatcher.prototype.watch = function watch(path, startTime) {
-	this.watchers[path] = this.watchers[path] || [];
+	this.watchers[formatPath(path)] = this.watchers[formatPath(path)] || [];
 	this.refs++;
 	var watcher = new Watcher(this, path, startTime);
 	watcher.on("closed", function() {
-		var idx = this.watchers[path].indexOf(watcher);
-		this.watchers[path].splice(idx, 1);
-		if(this.watchers[path].length === 0) {
-			delete this.watchers[path];
+		var idx = this.watchers[formatPath(path)].indexOf(watcher);
+		this.watchers[formatPath(path)].splice(idx, 1);
+		if(this.watchers[formatPath(path)].length === 0) {
+			delete this.watchers[formatPath(path)];
 			if(this.path === path)
 				this.setNestedWatching(false);
 		}
 		if(--this.refs <= 0)
 			this.close();
 	}.bind(this));
-	this.watchers[path].push(watcher);
+	this.watchers[formatPath(path)].push(watcher);
 	if(path === this.path) {
 		this.setNestedWatching(true);
 		var data = false;

--- a/test/DirectoryWatcher.test.js
+++ b/test/DirectoryWatcher.test.js
@@ -60,6 +60,24 @@ describe("DirectoryWatcher", function() {
 		});
 	});
 
+	it("should detect a file change with different case on windows", function(done) {
+		if(process.platform === "win32") {
+			var d = new DirectoryWatcher(fixtures);
+			testHelper.file("A");
+			var a = d.watch(path.join(fixtures, "a"));
+			a.on("change", function(mtime) {
+				mtime.should.be.type("number");
+				a.close();
+				done();
+			});
+			testHelper.tick(function() {
+				testHelper.file("a");
+			});
+		}else {
+			done();
+		}
+	});
+
 	it("should not detect a file change in initial scan", function(done) {
 		testHelper.file("a");
 		testHelper.tick(function() {


### PR DESCRIPTION
When files where being passed in with a different case than they have on disk, the change event did not work on Windows. We use webpack Require with lower casing, but the files on disk can have upper casing. This stopped the watch functionality from working. With this fix it works. I hope this PR is useful, if not please let me know or what changes to make. 

Thanks