### PR TITLE
Handle files that are deleted and recreated

### DIFF
--- a/lib/DirectoryWatcher.js
+++ b/lib/DirectoryWatcher.js
@@ -95,6 +95,7 @@ DirectoryWatcher.prototype.setFileTime = function setFileTime(filePath, mtime, i
 			});
 		}
 	} else if(!initial && !mtime) {
+		delete this.files[filePath];
 		if(this.watchers[withoutCase(filePath)]) {
 			this.watchers[withoutCase(filePath)].forEach(function(w) {
 				w.emit("remove");


### PR DESCRIPTION
If vim is set up to use a swap file, then when a save is changed, it
deletes the original file and renames the swap file into place.  This
can sometimes cause chokidar to send two events: "remove" and "add".
Because the DirectoryWatcher doesn't clear out removed files, the
subsequent add event is ignored and the change is not seen.