### PR TITLE
Ingore node_modules from chokidar

### DIFF
--- a/lib/DirectoryWatcher.js
+++ b/lib/DirectoryWatcher.js
@@ -54,6 +54,7 @@ function DirectoryWatcher(directoryPath, options) {
 		alwaysStat: true,
 		ignorePermissionErrors: true,
 		usePolling: options.poll ? true : undefined,
+                ignored: /node_modules/,
 		interval: typeof options.poll === "number" ? options.poll : undefined
 	});
 	this.watcher.on("add", this.onFileAdded.bind(this));


### PR DESCRIPTION
Not ignoring `node_modules` folder may have huge performance impact when using polling (#2). This ensures that `node_modules` folder is excluded from watch.