### PR TITLE
Store the options passed when contructing the DirectoryWatcher as an instance variable

### DIFF
--- a/lib/DirectoryWatcher.js
+++ b/lib/DirectoryWatcher.js
@@ -42,6 +42,7 @@ Watcher.prototype.close = function close() {
 
 function DirectoryWatcher(directoryPath, options) {
 	EventEmitter.call(this);
+	this.options = options;
 	this.path = directoryPath;
 	this.files = {};
 	this.directories = {};


### PR DESCRIPTION
It seems that the `createNestedWatched` function refers to `this.options` when creating a nested watcher, but this is never defined when creating the instance, so nested watchers do not get the correct options passed into them.

This manifested itself for me in polling for file changes (over a VirtualBox mount with either vboxsf or nfs) not working for deeply nested directories.

I'm not familiar with the Watchpack code so perhaps this isn't the correct/best fix, but it fixed my problem :) Open to any comments to improve it!