### PR TITLE
Add `ignored` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ var wp = new Watchpack({
 	// poll: 10000 - use polling with an interval of 10s
 	// poll defaults to undefined, which prefer native watching methods
 	// Note: enable polling when watching on a network path
+
+	ignored: /node_modules/,
+	// anymatch-compatible definition of files/paths to be ignored
+	// see https://github.com/paulmillr/chokidar#path-filtering
 });
 
 // Watchpack.prototype.watch(string[] files, string[] directories, [number startTime])

--- a/lib/DirectoryWatcher.js
+++ b/lib/DirectoryWatcher.js
@@ -53,6 +53,7 @@ function DirectoryWatcher(directoryPath, options) {
 		atomic: false,
 		alwaysStat: true,
 		ignorePermissionErrors: true,
+		ignored: options.ignored,
 		usePolling: options.poll ? true : undefined,
 		interval: typeof options.poll === "number" ? options.poll : undefined
 	});

--- a/lib/watchpack.js
+++ b/lib/watchpack.js
@@ -11,6 +11,7 @@ function Watchpack(options) {
 	if(!options.aggregateTimeout) options.aggregateTimeout = 200;
 	this.options = options;
 	this.watcherOptions = {
+		ignored: options.ignored,
 		poll: options.poll
 	};
 	this.fileWatchers = [];


### PR DESCRIPTION
Usage from webpack:

```js
watchOptions: {
  ignored: /node_modules/
}
```

This option will prevent watchpack from watching certain files/directories, which can improve performance when polling. A common scenario is to ignore the `node_modules` directory since you don't normally edit those files during development.
