### PR TITLE
Bump `async`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "should": "^8.3.1"
   },
   "dependencies": {
-    "async": "2.0.0-rc.4",
+    "async": "^2.1.2",
     "chokidar": "^1.4.3",
     "graceful-fs": "^4.1.2"
   }


### PR DESCRIPTION
To match the version used in webpack. Closes #13.