### PR TITLE
Emit change events for nested directory watchers

### DIFF
--- a/lib/DirectoryWatcher.js
+++ b/lib/DirectoryWatcher.js
@@ -83,7 +83,8 @@ DirectoryWatcher.prototype.setFileTime = function setFileTime(filePath, mtime, i
 	this.files[filePath] = [initial ? Math.min(now, mtime) : now, mtime];
 
 	// we add the fs accurency to reach the maximum possible mtime
-	mtime = mtime + FS_ACCURENCY;
+	if(mtime)
+		mtime = mtime + FS_ACCURENCY;
 
 	if(!old) {
 		if(mtime) {

--- a/lib/DirectoryWatcher.js
+++ b/lib/DirectoryWatcher.js
@@ -145,10 +145,15 @@ DirectoryWatcher.prototype.setDirectory = function setDirectory(directoryPath, e
 
 DirectoryWatcher.prototype.createNestedWatcher = function(directoryPath) {
 	this.directories[directoryPath] = watcherManager.watchDirectory(directoryPath, this.options, 1);
+	this.directories[directoryPath].directoryWatcher.parentInitialScan = this.initialScan;
 	this.directories[directoryPath].on("change", function(filePath, mtime) {
+		var directoryWatcher = this.directories[directoryPath].directoryWatcher;
+		var selfInitial = directoryWatcher.initialScan;
+		var parentInitial = directoryWatcher.parentInitialScan;
+		var initial = selfInitial && parentInitial;
 		if(this.watchers[withoutCase(this.path)]) {
 			this.watchers[withoutCase(this.path)].forEach(function(w) {
-				if(w.checkStartTime(mtime, false)) {
+				if(!initial || w.checkStartTime(mtime, false)) {
 					w.emit("change", filePath, mtime);
 				}
 			});


### PR DESCRIPTION
Fix #28

Change events are emitted on directory watchers for the immediate
directory being watched after the initial scan. Emit events from nested
watchers after their parents initial scan (they're a new directory) or
after their own scan (the directory existed during their parents
initial scan).