### PR TITLE
Add remove event

### DIFF
--- a/lib/watchpack.js
+++ b/lib/watchpack.js
@@ -19,6 +19,7 @@ function Watchpack(options) {
 	this.mtimes = {};
 	this.paused = false;
 	this.aggregatedChanges = [];
+	this.aggregatedRemovals = [];
 	this.aggregateTimeout = 0;
 	this._onTimeout = this._onTimeout.bind(this);
 }
@@ -93,6 +94,7 @@ Watchpack.prototype.getTimes = function() {
 
 Watchpack.prototype._fileWatcher = function _fileWatcher(file, watcher) {
 	watcher.on("change", this._onChange.bind(this, file));
+	watcher.on("remove", this._onRemove.bind(this, file));
 	return watcher;
 };
 
@@ -115,9 +117,22 @@ Watchpack.prototype._onChange = function _onChange(item, mtime, file) {
 	this.aggregateTimeout = setTimeout(this._onTimeout, this.options.aggregateTimeout);
 };
 
+Watchpack.prototype._onRemove = function _onRemove(item) {
+	delete this.mtimes[item];
+	if(this.paused) return;
+	this.emit("remove", item);
+	if(this.aggregateTimeout)
+		clearTimeout(this.aggregateTimeout);
+	if(this.aggregatedRemovals.indexOf(item) < 0)
+		this.aggregatedRemovals.push(item);
+	this.aggregateTimeout = setTimeout(this._onTimeout, this.options.aggregateTimeout);
+};
+
 Watchpack.prototype._onTimeout = function _onTimeout() {
 	this.aggregateTimeout = 0;
 	var changes = this.aggregatedChanges;
+	var removals = this.aggregatedRemovals;
 	this.aggregatedChanges = [];
-	this.emit("aggregated", changes);
+	this.aggregatedRemovals = [];
+	this.emit("aggregated", changes, removals);
 };

--- a/test/watchpack.js
+++ b/test/watchpack.js
@@ -449,4 +449,69 @@ describe("Watchpack", function() {
 			});
 		});
 	});
+
+	it("should watch a single file removal", function(done) {
+		testHelper.file("a");
+		var w = new Watchpack({
+			aggregateTimeout: 1000
+		});
+		var removeEvents = 0;
+		w.on("remove", function(file) {
+			file.should.be.eql(path.join(fixtures, "a"));
+			removeEvents++;
+		});
+		w.on("aggregated", function(changes, removals) {
+			removals.should.be.eql([path.join(fixtures, "a")]);
+			removeEvents.should.be.eql(1);
+			w.close();
+			done();
+		});
+		w.watch([path.join(fixtures, "a")], []);
+		testHelper.tick(function() {
+			testHelper.remove("a");
+		});
+	});
+
+	it("should watch multiple file removals", function(done) {
+		testHelper.file("a");
+		testHelper.file("b");
+		var w = new Watchpack({
+			aggregateTimeout: 1000
+		});
+		var removeEvents = [];
+		w.on("remove", function(file) {
+			if(removeEvents[removeEvents.length - 1] === file)
+				return;
+			removeEvents.push(file);
+		});
+		w.on("aggregated", function(changes, removals) {
+			removals.sort().should.be.eql([path.join(fixtures, "a"), path.join(fixtures, "b")]);
+			removeEvents.should.be.eql([
+				path.join(fixtures, "a"),
+				path.join(fixtures, "b"),
+				path.join(fixtures, "a"),
+				path.join(fixtures, "b"),
+			]);
+			Object.keys(w.getTimes()).sort().should.be.eql([]);
+			w.close();
+			done();
+		});
+		w.watch([path.join(fixtures, "a"), path.join(fixtures, "b")], []);
+		testHelper.tick(function() {
+			testHelper.remove("a");
+			testHelper.tick(function() {
+				testHelper.remove("b");
+				testHelper.tick(function() {
+					testHelper.file("a");
+					testHelper.file("b");
+					testHelper.tick(function() {
+						testHelper.remove("a");
+						testHelper.tick(function() {
+							testHelper.remove("b");
+						});
+					});
+				});
+			});
+		});
+	});
 });


### PR DESCRIPTION
Fixes https://github.com/webpack/watchpack/issues/27
Depends on https://github.com/webpack/watchpack/pull/33

- add the `remove` event
- enable to get removed files on the second argument of the `aggregate` event.

This is based on the work for [next.js](https://github.com/zeit/next.js), which we dynamically patch on runtime for now. cc @TheLarkInn 