### PR TITLE
Fixes webpack/webpack#762

### DIFF
--- a/lib/DirectoryWatcher.js
+++ b/lib/DirectoryWatcher.js
@@ -82,6 +82,8 @@ DirectoryWatcher.prototype.setFileTime = function setFileTime(filePath, mtime, i
 
 	this.files[filePath] = [initial ? Math.min(now, mtime) : now, mtime];
 
+	ensureFsAccuracy(mtime);
+
 	// we add the fs accurency to reach the maximum possible mtime
 	if(mtime)
 		mtime = mtime + FS_ACCURENCY;
@@ -231,16 +233,7 @@ DirectoryWatcher.prototype.onChange = function onChange(filePath, stat) {
 	if(filePath.indexOf(this.path) !== 0) return;
 	if(/[\\\/]/.test(filePath.substr(this.path.length + 1))) return;
 	var mtime = +stat.mtime;
-	if(FS_ACCURENCY > 1 && mtime % 1 !== 0)
-		FS_ACCURENCY = 1;
-	else if(FS_ACCURENCY > 10 && mtime % 10 !== 0)
-		FS_ACCURENCY = 10;
-	else if(FS_ACCURENCY > 100 && mtime % 100 !== 0)
-		FS_ACCURENCY = 100;
-	else if(FS_ACCURENCY > 1000 && mtime % 1000 !== 0)
-		FS_ACCURENCY = 1000;
-	else if(FS_ACCURENCY > 2000 && mtime % 2000 !== 0)
-		FS_ACCURENCY = 2000;
+	ensureFsAccuracy(mtime);
 	this.setFileTime(filePath, mtime, false, "change");
 };
 
@@ -333,3 +326,16 @@ DirectoryWatcher.prototype.close = function() {
 	}
 	this.emit("closed");
 };
+
+function ensureFsAccuracy(mtime) {
+	if(FS_ACCURENCY > 1 && mtime % 1 !== 0)
+		FS_ACCURENCY = 1;
+	else if(FS_ACCURENCY > 10 && mtime % 10 !== 0)
+		FS_ACCURENCY = 10;
+	else if(FS_ACCURENCY > 100 && mtime % 100 !== 0)
+		FS_ACCURENCY = 100;
+	else if(FS_ACCURENCY > 1000 && mtime % 1000 !== 0)
+		FS_ACCURENCY = 1000;
+	else if(FS_ACCURENCY > 2000 && mtime % 2000 !== 0)
+		FS_ACCURENCY = 2000;
+}


### PR DESCRIPTION
I believe this will fix webpack/webpack#762. I discovered that watch mode was firing an immediate rebuild because it thought files had changed that _were_ changed immediately prior to watch running, but not during the watch build. I think after this change there's still the possibility that sometimes a second rebuild is fired immediately, but the time window for it should be much shorter.

Let me know if I'm missing something.

Cheers!