### PR TITLE
Fix polling interval for binary files

### DIFF
--- a/lib/DirectoryWatcher.js
+++ b/lib/DirectoryWatcher.js
@@ -46,6 +46,7 @@ function DirectoryWatcher(directoryPath, options) {
 	this.path = directoryPath;
 	this.files = Object.create(null);
 	this.directories = Object.create(null);
+	var interval = typeof options.poll === "number" ? options.poll : undefined;
 	this.watcher = chokidar.watch(directoryPath, {
 		ignoreInitial: true,
 		persistent: true,
@@ -56,7 +57,8 @@ function DirectoryWatcher(directoryPath, options) {
 		ignorePermissionErrors: true,
 		ignored: options.ignored,
 		usePolling: options.poll ? true : undefined,
-		interval: typeof options.poll === "number" ? options.poll : undefined,
+		interval: interval,
+		binaryInterval: interval,
 		disableGlobbing: true
 	});
 	this.watcher.on("add", this.onFileAdded.bind(this));


### PR DESCRIPTION
Chokidar differentiates the polling interval for source files and binary files.  Passing only the `interval` option will make chokidar to poll binary files (ex: images) every 300ms (the default value) instead of the value specified by the webpack `watchOptions.poll` value.

You can verify this by using something like `strace -f -p $NODE_PID -e stat` to check the `stat` frequency for all watched files.