### PR TITLE
Bail out from watching earlier using watchOptions.ignored

### DIFF
--- a/lib/DirectoryWatcher.js
+++ b/lib/DirectoryWatcher.js
@@ -5,6 +5,7 @@
 var EventEmitter = require("events").EventEmitter;
 var async = require("async");
 var chokidar = require("chokidar");
+var anymatch = require('anymatch');
 var fs = require("graceful-fs");
 var path = require("path");
 
@@ -230,13 +231,14 @@ DirectoryWatcher.prototype.watch = function watch(filePath, startTime) {
 DirectoryWatcher.prototype.onFileAdded = function onFileAdded(filePath, stat) {
 	if(filePath.indexOf(this.path) !== 0) return;
 	if(/[\\\/]/.test(filePath.substr(this.path.length + 1))) return;
-
+	if(this.isIgnored(filePath)) return;
 	this.setFileTime(filePath, +stat.mtime, false, "add");
 };
 
 DirectoryWatcher.prototype.onDirectoryAdded = function onDirectoryAdded(directoryPath /*, stat */) {
 	if(directoryPath.indexOf(this.path) !== 0) return;
 	if(/[\\\/]/.test(directoryPath.substr(this.path.length + 1))) return;
+	if(this.isIgnored(directoryPath)) return;
 	this.setDirectory(directoryPath, true, false, "add");
 };
 
@@ -283,6 +285,7 @@ DirectoryWatcher.prototype.doInitialScan = function doInitialScan() {
 					callback();
 					return;
 				}
+				if(this.isIgnored(itemPath)) return;
 				if(stat.isFile()) {
 					if(!this.files[itemPath])
 						this.setFileTime(itemPath, +stat.mtime, true);
@@ -340,6 +343,10 @@ DirectoryWatcher.prototype.close = function() {
 	}
 	this.emit("closed");
 };
+
+DirectoryWatcher.prototype.isIgnored = function(itemPath) {
+	return this.options.ignored && anymatch(this.options.ignored, itemPath);
+}
 
 function ensureFsAccuracy(mtime) {
 	if(!mtime) return;

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "should": "^8.3.1"
   },
   "dependencies": {
+    "anymatch": "^1.3.2",
     "async": "^2.1.2",
     "chokidar": "^1.7.0",
     "graceful-fs": "^4.1.2"


### PR DESCRIPTION
### The Problem:

> Contrived example: https://github.com/d4rkr00t/watchpack-infinite-loop-example

In our case, we use monorepo with all of the dependencies in the root `node_modules` folder which are then symlinked to individual packages, we experience significant performance degradation, because watcher is going very deep through circular symlinks which slows down initial build time, and makes consequent re-builds extremely slow, and the CPU consumption is enormous. 

### What we've tried:

AFAIK Webpack has 2 ways of ignoring files from watch:
* `watchOptions.ignored` – they are passed down to chokidar. This one either not working properly in chokidar or I don't understand how it is supposed to work, because whatever I pass through this option isn't helping at all.
* `WatchIgnorePlugin` – that extends `NodeWatchFileSystem`. And can filter initial set of files, but DirectoryWatcher using `setNestedWatching` which adds nested directories to watch and that skips `WatchIgnorePlugin`.

### Temporary solution

We came up with a temporary solution that works for us right now, but it is very hacky. We are monkey patching `DirectoryWatcher` so it ignores `node_modules`:
```js
const DirectoryWatcher = require('watchpack/lib/DirectoryWatcher');
const _oldcreateNestedWatcher = DirectoryWatcher.prototype.createNestedWatcher;
DirectoryWatcher.prototype.createNestedWatcher = function(dirPath) {
  if (dirPath.includes('node_modules')) return;
  _oldcreateNestedWatcher.call(this, dirPath);
};
```
That helped a lot, re-builds now are almost instant, comparing to 30s - 60s before this fix. Though, we are not exactly happy about this solution :)

### Proposed solution

What I'm proposing in this PR is that we can use `watchOptions.ignored` to bail out from watching early. Thus breaking out of the circular symlinks hell. Also it speeds up everything a bit, since `watchpack` doesn't have to care about ignored folders/files.

Maybe you can suggest better approach for doing this. Or better places where I can add this check.

Also I haven't added any tests yet, since I didn't want to spend time writing them being not sure whether proposed approach is ok for you or not. But if it's fine with you, I'll add tests.

I looked at this PR https://github.com/webpack/watchpack/pull/41 which potentially can solve this issue, but since it has probably died almost a year ago I think considering other options make total sense.