### PR TITLE
Grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Wrapper library for directory and file watching.
 
 ## Concept
 
-watchpack high level API don't map directly to watchers. Instead a three level architecture ensures that for each directory only a single watcher exists.
+watchpack high level API doesn't map directly to watchers. Instead a three level architecture ensures that for each directory only a single watcher exists.
 
 * The high level API requests `DirectoryWatchers` from a `WatcherManager`, which ensures that only a single `DirectoryWatcher` per directory is created.
 * A user-faced `Watcher` can be obtained from a `DirectoryWatcher` and provides a filtered view on the `DirectoryWatcher`.


### PR DESCRIPTION
I'm not a fan of this line, It probably would be better as:

> watchpack's high level API doesn't map directly...