### PR TITLE
Add option to change followSymlinks

### DIFF
--- a/lib/DirectoryWatcher.js
+++ b/lib/DirectoryWatcher.js
@@ -53,7 +53,7 @@ function DirectoryWatcher(directoryPath, options) {
 	this.watcher = chokidar.watch(directoryPath, {
 		ignoreInitial: true,
 		persistent: true,
-		followSymlinks: false,
+		followSymlinks: !!options.followSymlinks,
 		depth: 0,
 		atomic: false,
 		alwaysStat: true,


### PR DESCRIPTION
There is many projects who need to configure this option. This simple PR allow to pass a `followSymlinks` options to change it. Default is still `false`.


Webpack issue:
https://github.com/webpack/webpack/issues/1866

Watchpack issue:
https://github.com/webpack/watchpack/issues/61