### PR TITLE
Bump chokidar minor version to allow node>=10

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "should": "^8.3.1"
   },
   "dependencies": {
-    "chokidar": "^2.0.2",
+    "chokidar": "^2.0.4",
     "graceful-fs": "^4.1.2",
     "neo-async": "^2.5.0"
   }


### PR DESCRIPTION
I'm currently seeing an engine incompatibility error when I install webpack on Node 10:

```bash
error upath@1.0.4: The engine "node" is incompatible with this module. Expected version ">=4 <=9".
```

Running npm ls yields:

```bash
$ npm ls upath
├─┬ @babel/cli@7.0.0
│ └─┬ chokidar@2.0.4
│   └── upath@1.1.0
└─┬ webpack@4.19.0
  └─┬ watchpack@1.5.0
    └─┬ chokidar@2.0.2
      └── upath@1.0.4
```

chokidar uses an older version of upath where it restricts node engine to <=9. The issue was addressed in https://github.com/anodynos/upath/commit/8c5f4e10376ed1cd4553d9432297d39a34410c69 and the latest version of chokidar is now using a upath that is compatible with Node 10.  