### PR TITLE
Fix removal test

### DIFF
--- a/test/DirectoryWatcher.test.js
+++ b/test/DirectoryWatcher.test.js
@@ -151,7 +151,7 @@ describe("DirectoryWatcher", function() {
 		var d = new DirectoryWatcher(fixtures, {});
 		var a = d.watch(path.join(fixtures, "a"));
 		a.on("remove", function(mtime) {
-			(typeof mtime === 'undefined').should.be.true;
+			(typeof mtime === 'undefined').should.be.true();
 			a.close();
 			done();
 		});

--- a/test/DirectoryWatcher.test.js
+++ b/test/DirectoryWatcher.test.js
@@ -150,8 +150,8 @@ describe("DirectoryWatcher", function() {
 		testHelper.file("a");
 		var d = new DirectoryWatcher(fixtures, {});
 		var a = d.watch(path.join(fixtures, "a"));
-		a.on("remove", function(mtime) {
-			(typeof mtime === 'undefined').should.be.true();
+		a.on("remove", function(type) {
+			(type === 'unlink').should.be.true();
 			a.close();
 			done();
 		});


### PR DESCRIPTION
Currently the "should detect a file removal" test doesn't run the assertion at all due to shouldjs change ( https://github.com/shouldjs/should.js/wiki/Breaking-changes#changes-for-7x )

Fixing this causes the test to fail (1st commit)

Looks like the event signature for removal changed at some point as well so this also changes to match that so the test passes. (2nd commit)