### PR TITLE
Output errors from chokidar to stderr

### DIFF
--- a/lib/DirectoryWatcher.js
+++ b/lib/DirectoryWatcher.js
@@ -280,9 +280,10 @@ DirectoryWatcher.prototype.onDirectoryUnlinked = function onDirectoryUnlinked(di
 	if(this.initialScan) {
 		this.initialScanRemoved.push(directoryPath);
 	}
-};
+}
 
-DirectoryWatcher.prototype.onWatcherError = function onWatcherError(/* err */) {
+DirectoryWatcher.prototype.onWatcherError = function onWatcherError(err) {
+	console.error("Watchpack Error: " + err);
 };
 
 DirectoryWatcher.prototype.doInitialScan = function doInitialScan() {

--- a/lib/DirectoryWatcher.js
+++ b/lib/DirectoryWatcher.js
@@ -280,7 +280,7 @@ DirectoryWatcher.prototype.onDirectoryUnlinked = function onDirectoryUnlinked(di
 	if(this.initialScan) {
 		this.initialScanRemoved.push(directoryPath);
 	}
-}
+};
 
 DirectoryWatcher.prototype.onWatcherError = function onWatcherError(err) {
 	console.error("Watchpack Error: " + err);

--- a/test/DirectoryWatcher.test.js
+++ b/test/DirectoryWatcher.test.js
@@ -159,4 +159,24 @@ describe("DirectoryWatcher", function() {
 			testHelper.remove("a");
 		});
 	});
+
+	it("should log errors emitted from chokidar to stderr", function(done) {
+		var error_logged = false;
+		var old_stderr = process.stderr.write
+		process.stderr.write = function(a){ 
+			console.log(a);
+			error_logged = true; 
+		} 
+		var d = new DirectoryWatcher(fixtures, {});
+		var a = d.watch(path.join(fixtures, "a"));
+		d.watcher._emit("error", "error_message");
+		
+		testHelper.tick(function(){
+			a.close();
+			process.stderr.write = old_stderr;
+			error_logged.should.be.true();
+			done();
+		})
+
+	})
 });


### PR DESCRIPTION
This fixes issue:
https://github.com/webpack/webpack/issues/8101

There doesn't seem to be any channel for watchpack to report errors up to webpack which is probably a better long term solution but this at least gives users relevant error messages. 

The test isn't super great  but since watchpack ignores access errors I can't come up with a way to trigger a real error without sudo but I have tested it manually by using yarn link and setting my inotify.max_user_watches to a low value and it reports the errors correctly. 