### PR TITLE
Return a Map from `getTimes` instead of an object.

### DIFF
--- a/lib/DirectoryWatcher.js
+++ b/lib/DirectoryWatcher.js
@@ -546,30 +546,29 @@ class DirectoryWatcher extends EventEmitter {
 	}
 
 	getTimes() {
-		const obj = Object.create(null);
+		const obj = new Map();
 		let safeTime = this.lastWatchEvent;
 		for(const [file, entry] of this.files) {
 			fixupEntryAccuracy(entry);
 			safeTime = Math.max(safeTime, entry.safeTime);
-			obj[file] = Math.max(entry.safeTime, entry.timestamp);
+			obj.set(file, Math.max(entry.safeTime, entry.timestamp));
 		}
 		if(this.nestedWatching) {
 			for(const w of this.directories.values()) {
 				const times = w.directoryWatcher.getTimes();
-				Object.keys(times).forEach(function(file) {
-					const time = times[file];
+				for (const [file, time] of times) {
 					safeTime = Math.max(safeTime, time);
-					obj[file] = time;
-				});
+					obj.set(file, time)	
+				}
 			}
-			obj[this.path] = safeTime;
+			obj.set(this.path, safeTime);
 		}
 		if(!this.initialScan) {
 			for(const watchers of this.watchers.values()) {
 				for(const watcher of watchers) {
 					const path = watcher.path;
-					if(!Object.prototype.hasOwnProperty.call(obj, path)) {
-						obj[path] = null;
+					if (!obj.has(path)) {
+						obj.set(path, null)
 					}
 				}
 			}

--- a/lib/watchpack.js
+++ b/lib/watchpack.js
@@ -71,10 +71,12 @@ class Watchpack extends EventEmitter {
 		const directoryWatchers = new Set();
 		addWatchersToSet(this.fileWatchers, directoryWatchers);
 		addWatchersToSet(this.dirWatchers, directoryWatchers);
-		const obj = Object.create(null);
+		const obj = new Map();
 		for(const w of directoryWatchers) {
 			const times = w.getTimes();
-			Object.keys(times).forEach(file => obj[file] = times[file]);
+			for (const [file, time] of times) {
+				obj.set(file, time);
+			}
 		}
 		return obj;
 	}

--- a/test/DirectoryWatcher.test.js
+++ b/test/DirectoryWatcher.test.js
@@ -41,7 +41,7 @@ describe("DirectoryWatcher", function() {
 		var a = d.watch(path.join(fixtures, "a"));
 		a.on("change", function(mtime) {
 			mtime.should.be.type("number");
-			Object.keys(d.getTimes()).sort().should.be.eql([
+			[...d.getTimes().keys()].sort().should.be.eql([
 				path.join(fixtures, "a")
 			]);
 			a.close();

--- a/test/Watchpack.js
+++ b/test/Watchpack.js
@@ -54,7 +54,7 @@ describe("Watchpack", function() {
 				path.join(fixtures, "b"),
 				path.join(fixtures, "a")
 			]);
-			Object.keys(w.getTimes()).sort().should.be.eql([
+			[...w.getTimes().keys()].sort().should.be.eql([
 				path.join(fixtures, "a"),
 				path.join(fixtures, "b")
 			]);
@@ -408,7 +408,7 @@ describe("Watchpack", function() {
 			changeEvents.should.be.eql([
 				path.join(fixtures, "dir", "sub", "sub", "a")
 			]);
-			Object.keys(w.getTimes()).sort().should.be.eql([
+			[...w.getTimes().keys()].sort().should.be.eql([
 				path.join(fixtures, "dir"),
 				path.join(fixtures, "dir", "sub"),
 				path.join(fixtures, "dir", "sub", "sub"),
@@ -618,7 +618,7 @@ describe("Watchpack", function() {
 					path.join(fixtures, "b"),
 				]);
 			}
-			Object.keys(w.getTimes()).sort().should.be.eql([
+			[...w.getTimes().keys()].sort().should.be.eql([
 				path.join(fixtures, "a"),
 				path.join(fixtures, "b")
 			]);


### PR DESCRIPTION
Whenever the current `webpack` alpha [calls `getTimes`](https://github.com/webpack/webpack/blob/af4cb35784be468c32da5b79c33b88e83cad1257/lib/node/NodeWatchFileSystem.js#L54) it immediately runs the output through a utility function that turns the resultant object into a Map.  Change this here and fix it there and it'll save iterating through all watched paths.
This is breaking, but it's still in beta and the `webpack` alpha uses a pinned version so maybe it's okay.