### PR TITLE
watcherManager add fileSystem

### DIFF
--- a/lib/DirectoryWatcher.js
+++ b/lib/DirectoryWatcher.js
@@ -6,10 +6,7 @@
 
 const EventEmitter = require("events").EventEmitter;
 const async = require("neo-async");
-const fs = require("graceful-fs");
 const path = require("path");
-
-const watcherManager = require("./watcherManager");
 
 const EXISTANCE_ONLY_TIME_ENTRY = Object.freeze({});
 
@@ -45,12 +42,13 @@ class Watcher extends EventEmitter {
 }
 
 class DirectoryWatcher extends EventEmitter {
-	constructor(directoryPath, options) {
+	constructor(directoryPath, options, watcherManager) {
 		super();
 		if(FORCE_POLLING) {
 			options.poll = FORCE_POLLING;
 		}
 		this.options = options;
+		this.watcherManager = watcherManager
 		this.path = directoryPath;
 		// safeTime is the point in time after which reading is safe to be unchanged
 		// timestamp is a value that should be compared with another timestamp (mtime)
@@ -80,10 +78,10 @@ class DirectoryWatcher extends EventEmitter {
 			// TODO options.ignored
 			if(this.polledWatching) {
 				const listener = this.onWatchFileEvent.bind(this);
-				fs.watchFile(this.path, { persistent: true, interval: this.polledWatching }, listener);
+				this.watcherManager.fileSystem.watchFile(this.path, { persistent: true, interval: this.polledWatching }, listener);
 				// Fallback to caputure too late attached watchers
 				const timeout = setTimeout(() => {
-					fs.stat(this.path, (err, stats) => {
+					this.watcherManager.fileSystem.stat(this.path, (err, stats) => {
 						if(!err) {
 							listener(stats);
 						}
@@ -92,14 +90,14 @@ class DirectoryWatcher extends EventEmitter {
 				this.watcher = {
 					close: () => {
 						clearTimeout(timeout);
-						fs.unwatchFile(this.path, listener);
+						this.watcherManager.fileSystem.unwatchFile(this.path, listener);
 					}
 				};
 			} else {
 				if(IS_OSX) {
 					this.watchInParentDirectory();
 				}
-				this.watcher = fs.watch(this.path);
+				this.watcher = this.watcherManager.fileSystem.watch(this.path);
 				this.watcher.on("change", this.onWatchEvent.bind(this));
 				this.watcher.on("error", this.onWatcherError.bind(this));
 			}
@@ -148,7 +146,7 @@ class DirectoryWatcher extends EventEmitter {
 			const oldListener = this.filesWatchListener.get(itemPath);
 			if(oldListener) {
 				this.filesWatchListener.delete(itemPath);
-				fs.unwatchFile(itemPath, oldListener);
+				this.watcherManager.fileSystem.unwatchFile(itemPath, oldListener);
 			}
 		}
 	}
@@ -236,7 +234,7 @@ class DirectoryWatcher extends EventEmitter {
 	}
 
 	createNestedWatcher(directoryPath) {
-		const watcher = watcherManager.watchDirectory(directoryPath, this.options, 1);
+		const watcher = this.watcherManager.watchDirectory(directoryPath, this.options, 1);
 		watcher.on("change", (filePath, mtime, type) => {
 			this.forEachWatcher(this.path, w => {
 				if(w.checkStartTime(mtime, false)) {
@@ -251,11 +249,11 @@ class DirectoryWatcher extends EventEmitter {
 		if(!this.filesWatchListener.has(path)) {
 			const listener = this.onWatchFileChildEvent.bind(this, path);
 			this.filesWatchListener.set(path, listener);
-			fs.watchFile(path, { persistent: true, interval: this.polledWatching }, listener);
+			this.watcherManager.fileSystem.watchFile(path, { persistent: true, interval: this.polledWatching }, listener);
 			// It's possible that we miss the first event
 			// so we have a fallback after 1s
 			setTimeout(() => {
-				fs.stat(path, (err, stats) => {
+				this.watcherManager.fileSystem.stat(path, (err, stats) => {
 					if(!err) {
 						listener(stats);
 					}
@@ -346,7 +344,7 @@ class DirectoryWatcher extends EventEmitter {
 				if(this.closed) return;
 				this._activeEvents.set(filename, false);
 				const filePath = path.join(this.path, filename);
-				fs.stat(filePath, (err, stats) => {
+				this.watcherManager.fileSystem.stat(filePath, (err, stats) => {
 					if(this.closed) return;
 					if(this._activeEvents.get(filename) === true) {
 						process.nextTick(checkStats);
@@ -361,7 +359,7 @@ class DirectoryWatcher extends EventEmitter {
 						} else {
 							if(filename === path.basename(this.path)) {
 								// This may indicate that the directory itself was removed
-								if(!fs.existsSync(this.path)) {
+								if(!this.watcherManager.fileSystem.existsSync(this.path)) {
 									this.onDirectoryRemoved();
 								}
 							}
@@ -454,7 +452,7 @@ class DirectoryWatcher extends EventEmitter {
 			// removing directories in the root directory is not supported
 			if(path.dirname(parentDir) === parentDir) return;
 
-			this.parentWatcher = watcherManager.watchFile(this.path, this.options, 1);
+			this.parentWatcher = this.watcherManager.watchFile(this.path, this.options, 1);
 			this.parentWatcher.on("change", (mtime, type) => {
 				if(this.closed) return;
 
@@ -485,7 +483,7 @@ class DirectoryWatcher extends EventEmitter {
 			return;
 		}
 		this.scanning = true;
-		fs.readdir(this.path, (err, items) => {
+		this.watcherManager.fileSystem.readdir(this.path, (err, items) => {
 			if(this.closed) return;
 			if(err) {
 				if(err.code === "ENOENT" || err.code === "EPERM") {
@@ -509,7 +507,7 @@ class DirectoryWatcher extends EventEmitter {
 				return;
 			}
 			async.forEach(itemPaths, (itemPath, callback) => {
-				fs.stat(itemPath, (err2, stats) => {
+				this.watcherManager.fileSystem.stat(itemPath, (err2, stats) => {
 					if(this.closed) return;
 					if(err2) {
 						if(err2.code === "ENOENT" || err2.code === "EPERM" || err2.code === "EBUSY") {
@@ -632,7 +630,7 @@ class DirectoryWatcher extends EventEmitter {
 			this.directories.clear();
 		}
 		for(const [file, listener] of this.filesWatchListener) {
-			fs.unwatchFile(file, listener);
+			this.watcherManager.fileSystem.unwatchFile(file, listener);
 		}
 		this.filesWatchListener.clear();
 		if(this.parentWatcher) {

--- a/lib/watcherManager.js
+++ b/lib/watcherManager.js
@@ -4,12 +4,14 @@
 */
 "use strict";
 
+const fs = require("graceful-fs");
 const path = require("path");
 
 let DirectoryWatcher;
 
 class WatcherManager {
-	constructor() {
+	constructor(fileSystem) {
+		this.fileSystem = fileSystem || fs;
 		this.directoryWatchers = new Map();
 	}
 
@@ -21,7 +23,7 @@ class WatcherManager {
 		const key = directory + " " + JSON.stringify(options);
 		const watcher = this.directoryWatchers.get(key);
 		if(watcher === undefined) {
-			const newWatcher = new DirectoryWatcher(directory, options);
+			const newWatcher = new DirectoryWatcher(directory, options, this);
 			this.directoryWatchers.set(key, newWatcher);
 			newWatcher.on("closed", () => {
 				this.directoryWatchers.delete(key);
@@ -41,4 +43,4 @@ class WatcherManager {
 	}
 }
 
-module.exports = new WatcherManager();
+module.exports = WatcherManager;

--- a/lib/watchpack.js
+++ b/lib/watchpack.js
@@ -4,7 +4,7 @@
 */
 "use strict";
 
-const watcherManager = require("./watcherManager");
+const WatcherManager = require("./watcherManager");
 const EventEmitter = require("events").EventEmitter;
 
 let EXISTANCE_ONLY_TIME_ENTRY; // lazy required
@@ -24,6 +24,7 @@ class Watchpack extends EventEmitter {
 		if(!options) options = {};
 		if(!options.aggregateTimeout) options.aggregateTimeout = 200;
 		this.options = options;
+		this.watcherManager = new WatcherManager(options.fileSystem);
 		this.watcherOptions = {
 			ignored: options.ignored,
 			poll: options.poll
@@ -42,10 +43,10 @@ class Watchpack extends EventEmitter {
 		const oldFileWatchers = this.fileWatchers;
 		const oldDirWatchers = this.dirWatchers;
 		this.fileWatchers = files.map(file =>
-			this._fileWatcher(file, watcherManager.watchFile(file, this.watcherOptions, startTime))
+			this._fileWatcher(file, this.watcherManager.watchFile(file, this.watcherOptions, startTime))
 		);
 		this.dirWatchers = directories.map(dir =>
-			this._dirWatcher(dir, watcherManager.watchDirectory(dir, this.watcherOptions, startTime))
+			this._dirWatcher(dir, this.watcherManager.watchDirectory(dir, this.watcherOptions, startTime))
 		);
 		oldFileWatchers.forEach(w => w.close());
 		oldDirWatchers.forEach(w => w.close());

--- a/test/DirectoryWatcher.test.js
+++ b/test/DirectoryWatcher.test.js
@@ -5,6 +5,7 @@ require("should");
 var path = require("path");
 var TestHelper = require("./helpers/TestHelper");
 var OrgDirectoryWatcher = require("../lib/DirectoryWatcher");
+var WatcherManager = require("../lib/watcherManager");
 
 var fixtures = path.join(__dirname, "fixtures");
 var testHelper = new TestHelper(fixtures);
@@ -12,7 +13,7 @@ var testHelper = new TestHelper(fixtures);
 var openWatchers = [];
 
 var DirectoryWatcher = function(p, options) {
-	var d = new OrgDirectoryWatcher(p, options);
+	var d = new OrgDirectoryWatcher(p, options, new WatcherManager());
 	openWatchers.push(d);
 	var orgClose = d.close;
 	d.close = function() {

--- a/test/helpers/TestHelper.js
+++ b/test/helpers/TestHelper.js
@@ -4,7 +4,8 @@ var fs = require("fs");
 var path = require("path");
 var rimraf = require("rimraf");
 
-var watcherManager = require("../../lib/watcherManager");
+var WatcherManager = require("../../lib/watcherManager");
+var watcherManager = new WatcherManager();
 
 function TestHelper(testdir) {
 	this.testdir = testdir;


### PR DESCRIPTION
1、exports WatcherManager
2、WatcherManager add fileSystem

---

more see: https://github.com/webpack/watchpack/pull/94 https://github.com/webpack/watchpack/issues/95

---

> Many times, for example, building on a development machine will be slower, and the development machine is most likely a window. At this time, I hope that the build is built on linux and then developed in the development server. At this time, WebSocket will be used to virtualize one. The file system is on webpack. At this time, the custom inputFileSystem is used, so it needs to be built by remote. At this time, we can no longer rely on the local graceful-fs. We expect the watchpack to support the custom file system just like webpack. thank you very much.
> In fact, the method of implementing the remote file system has this reference [fs-remote](https://www.npmjs.com/package/fs-remote), but not only this
> 
> /ping @sokra
> 
> Thank you very much for your enthusiasm and support, but I still don't write test at the moment. This pr is my own guess. I will try my best to study how the test is implemented. I also hope that you have a better solution. In fact, I just want to. To implement file system remote words, such as the old version depends on chokidar.watch, in fact, we can use the configuration of the chokidarWatch function, because I can provide a remote, chokidarWatch, also through the [WebSocket remote call](https://www.npmjs.com/package/run-on-server)
> 
> /ping @evilebottnawi

