### PR TITLE
Fix watchpack.js?

### DIFF
--- a/lib/watchpack.js
+++ b/lib/watchpack.js
@@ -128,17 +128,17 @@ class Watchpack extends EventEmitter {
 		this.emit("change", file, mtime, type);
 		if(this.aggregateTimeout)
 			clearTimeout(this.aggregateTimeout);
-		this.aggregatedChanges.add(item);
+		this.aggregatedChanges.add(file);
 		this.aggregateTimeout = setTimeout(this._onTimeout, this.options.aggregateTimeout);
 	}
 
 	_onRemove(item, file) {
 		file = file || item;
 		if(this.paused) return;
-		this.emit("remove", item);
+		this.emit("remove", file);
 		if(this.aggregateTimeout)
 			clearTimeout(this.aggregateTimeout);
-		this.aggregatedRemovals.add(item);
+		this.aggregatedRemovals.add(file);
 		this.aggregateTimeout = setTimeout(this._onTimeout, this.options.aggregateTimeout);
 	}
 


### PR DESCRIPTION
This makes the aggregate event changes/removals arrays have full file paths, is there any reason this isn't implemented?