### PR TITLE
Fix:10071 - Accept watchOptions.aggregateTimeout be 0

### DIFF
--- a/lib/watchpack.js
+++ b/lib/watchpack.js
@@ -64,7 +64,9 @@ class Watchpack extends EventEmitter {
 	constructor(options) {
 		super();
 		if (!options) options = {};
-		if (!options.aggregateTimeout) options.aggregateTimeout = 200;
+		if (typeof this.options.aggregateTimeout !== "number") {
+			this.options.aggregateTimeout = 200;
+		}
 		this.options = options;
 		this.watcherOptions = cachedNormalizeOptions(options);
 		this.watcherManager = getWatcherManager(this.watcherOptions);

--- a/lib/watchpack.js
+++ b/lib/watchpack.js
@@ -64,8 +64,8 @@ class Watchpack extends EventEmitter {
 	constructor(options) {
 		super();
 		if (!options) options = {};
-		if (typeof this.options.aggregateTimeout !== "number") {
-			this.options.aggregateTimeout = 200;
+		if (typeof options.aggregateTimeout !== "number") {
+			options.aggregateTimeout = 200;
 		}
 		this.options = options;
 		this.watcherOptions = cachedNormalizeOptions(options);


### PR DESCRIPTION
Handles : [#10071](https://github.com/webpack/webpack/issues/10071)

Aligned with 
https://github.com/webpack/webpack/pull/10118