### PR TITLE
Fix case renames not marking previous casing as missing in time entries

### DIFF
--- a/lib/DirectoryWatcher.js
+++ b/lib/DirectoryWatcher.js
@@ -64,6 +64,8 @@ class DirectoryWatcher extends EventEmitter {
 		// timestamp is a value that should be compared with another timestamp (mtime)
 		/** @type {Map<string, { safeTime: number, timestamp: number }} */
 		this.files = new Map();
+		/** @type {Map<string, number>} */
+		this.filesWithoutCase = new Map();
 		this.directories = new Map();
 		this.lastWatchEvent = 0;
 		this.initialScan = true;
@@ -86,15 +88,6 @@ class DirectoryWatcher extends EventEmitter {
 		this.scanning = false;
 		this.scanAgain = false;
 		this.scanAgainInitial = false;
-		this.isCaseInsensitive = undefined;
-
-		// check if we're on a case insensitive system
-		try {
-			fs.statSync(__dirname.toUpperCase());
-			this.isCaseInsensitive = true;
-		} catch (_) {
-			this.isCaseInsensitive = false;
-		}
 
 		this.createWatcher();
 		this.doScan(true);
@@ -163,8 +156,15 @@ class DirectoryWatcher extends EventEmitter {
 		const oldFile = this.files.get(itemPath);
 		if (oldFile) {
 			this.files.delete(itemPath);
+			const key = withoutCase(itemPath);
+			const count = this.filesWithoutCase.get(key) - 1;
+			if (count <= 0) {
+				this.filesWithoutCase.delete(key);
+				this.forEachWatcher(itemPath, w => w.emit("remove", type));
+			} else {
+				this.filesWithoutCase.set(key, count);
+			}
 
-			this.forEachWatcher(itemPath, w => w.emit("remove", type));
 			if (!initial) {
 				this.forEachWatcher(this.path, w =>
 					w.emit("change", itemPath, null, type)
@@ -207,6 +207,18 @@ class DirectoryWatcher extends EventEmitter {
 		this._cachedTimeInfoEntries = undefined;
 
 		if (!old) {
+			const key = withoutCase(filePath);
+			const count = this.filesWithoutCase.get(key);
+			this.filesWithoutCase.set(key, (count || 0) + 1);
+			if (count !== undefined) {
+				// There is already a file with case-insenstive-equal name
+				// On a case-insenstive filesystem we may miss the renaming
+				// when only casing is changed.
+				// To be sure that our information is correct
+				// we trigger a rescan here
+				this.doScan(false);
+			}
+
 			this.forEachWatcher(filePath, w => {
 				if (!initial || w.checkStartTime(safeTime, initial)) {
 					w.emit("change", mtime, type);
@@ -383,44 +395,6 @@ class DirectoryWatcher extends EventEmitter {
 						return;
 					}
 					this._activeEvents.delete(filename);
-
-					if (this.isCaseInsensitive) {
-						// we need to make sure the file's casing wasn't
-						// changed on a case insensitive filesystem
-						const noCaseFilePath = withoutCase(filePath);
-						const dirCache = {};
-
-						for (const file of Array.from(this.files.keys()).concat(filePath)) {
-							if (withoutCase(file) === noCaseFilePath) {
-								const curFileDir = path.dirname(file);
-
-								if (!dirCache[curFileDir]) {
-									try {
-										dirCache[curFileDir] = fs.readdirSync(curFileDir);
-									} catch (err) {
-										if (err.code === "ENOENT" || err.code === "EPERM") {
-											this.setMissing(file, false, eventType);
-											if (file === filePath) return;
-											break;
-										}
-										throw err;
-									}
-								}
-								const curFilename = path.basename(file);
-
-								if (
-									!dirCache[curFileDir].some(curFile => curFile === curFilename)
-								) {
-									this.setMissing(file, false, eventType);
-									// make sure to return so we don't re-add it below
-									if (file === filePath) {
-										return;
-									}
-								}
-							}
-						}
-					}
-
 					// ENOENT happens when the file/directory doesn't exist
 					// EPERM happens when the containing directory doesn't exist
 					if (err) {

--- a/lib/DirectoryWatcher.js
+++ b/lib/DirectoryWatcher.js
@@ -374,6 +374,42 @@ class DirectoryWatcher extends EventEmitter {
 						return;
 					}
 					this._activeEvents.delete(filename);
+
+					// we need to make sure the file's casing wasn't
+					// changed on a case insensitive filesystem
+					const noCaseFilePath = withoutCase(filePath);
+					const dirCache = {};
+
+					for (const file of Array.from(this.files.keys()).concat(filePath)) {
+						if (withoutCase(file) === noCaseFilePath) {
+							const curFileDir = path.dirname(file);
+
+							if (!dirCache[curFileDir]) {
+								try {
+									dirCache[curFileDir] = fs.readdirSync(curFileDir);
+								} catch (err) {
+									if (err.code === "ENOENT" || err.code === "EPERM") {
+										this.setMissing(file, false, eventType);
+										if (file === filePath) return;
+										break;
+									}
+									throw err;
+								}
+							}
+							const curFilename = path.basename(file);
+
+							if (
+								!dirCache[curFileDir].some(curFile => curFile === curFilename)
+							) {
+								this.setMissing(file, false, eventType);
+								// make sure to return so we don't re-add it below
+								if (file === filePath) {
+									return;
+								}
+							}
+						}
+					}
+
 					// ENOENT happens when the file/directory doesn't exist
 					// EPERM happens when the containing directory doesn't exist
 					if (err) {

--- a/lib/DirectoryWatcher.js
+++ b/lib/DirectoryWatcher.js
@@ -86,6 +86,15 @@ class DirectoryWatcher extends EventEmitter {
 		this.scanning = false;
 		this.scanAgain = false;
 		this.scanAgainInitial = false;
+		this.isCaseInsensitive = undefined;
+
+		// check if we're on a case insensitive system
+		try {
+			fs.statSync(__dirname.toUpperCase());
+			this.isCaseInsensitive = true;
+		} catch (_) {
+			this.isCaseInsensitive = false;
+		}
 
 		this.createWatcher();
 		this.doScan(true);
@@ -375,36 +384,38 @@ class DirectoryWatcher extends EventEmitter {
 					}
 					this._activeEvents.delete(filename);
 
-					// we need to make sure the file's casing wasn't
-					// changed on a case insensitive filesystem
-					const noCaseFilePath = withoutCase(filePath);
-					const dirCache = {};
+					if (this.isCaseInsensitive) {
+						// we need to make sure the file's casing wasn't
+						// changed on a case insensitive filesystem
+						const noCaseFilePath = withoutCase(filePath);
+						const dirCache = {};
 
-					for (const file of Array.from(this.files.keys()).concat(filePath)) {
-						if (withoutCase(file) === noCaseFilePath) {
-							const curFileDir = path.dirname(file);
+						for (const file of Array.from(this.files.keys()).concat(filePath)) {
+							if (withoutCase(file) === noCaseFilePath) {
+								const curFileDir = path.dirname(file);
 
-							if (!dirCache[curFileDir]) {
-								try {
-									dirCache[curFileDir] = fs.readdirSync(curFileDir);
-								} catch (err) {
-									if (err.code === "ENOENT" || err.code === "EPERM") {
-										this.setMissing(file, false, eventType);
-										if (file === filePath) return;
-										break;
+								if (!dirCache[curFileDir]) {
+									try {
+										dirCache[curFileDir] = fs.readdirSync(curFileDir);
+									} catch (err) {
+										if (err.code === "ENOENT" || err.code === "EPERM") {
+											this.setMissing(file, false, eventType);
+											if (file === filePath) return;
+											break;
+										}
+										throw err;
 									}
-									throw err;
 								}
-							}
-							const curFilename = path.basename(file);
+								const curFilename = path.basename(file);
 
-							if (
-								!dirCache[curFileDir].some(curFile => curFile === curFilename)
-							) {
-								this.setMissing(file, false, eventType);
-								// make sure to return so we don't re-add it below
-								if (file === filePath) {
-									return;
+								if (
+									!dirCache[curFileDir].some(curFile => curFile === curFilename)
+								) {
+									this.setMissing(file, false, eventType);
+									// make sure to return so we don't re-add it below
+									if (file === filePath) {
+										return;
+									}
 								}
 							}
 						}

--- a/test/Casing.js
+++ b/test/Casing.js
@@ -44,5 +44,71 @@ if (fsIsCaseInsensitive) {
 				testHelper.file("A");
 			});
 		});
+
+		it("should mark as missing on changing filename casing (dir watch)", function(done) {
+			var w = new Watchpack({
+				aggregateTimeout: 1000
+			});
+			var dir = "case-rename";
+			var testFile = path.join(dir, "hello.txt");
+			var testFileRename = path.join(dir, "hEllO.txt");
+			testHelper.dir(dir);
+			testHelper.file(testFile);
+
+			let afterRename = false;
+
+			w.on("aggregated", function(changes, removals) {
+				if (!afterRename) return;
+				const files = w.getTimeInfoEntries();
+				w.close();
+
+				for (const file of files.keys()) {
+					if (file.endsWith("hello.txt")) {
+						return done(new Error(`Renamed file was still in timeInfoEntries`));
+					}
+				}
+				return done();
+			});
+
+			w.watch([], [path.join(fixtures, "case-rename")], 0);
+
+			testHelper.tick(function() {
+				afterRename = true;
+				testHelper.rename(testFile, testFileRename);
+			});
+		});
+
+		it("should mark as missing on changing filename casing (file watch)", function(done) {
+			var w = new Watchpack({
+				aggregateTimeout: 1000
+			});
+			var dir = "case-rename";
+			var testFile = path.join(dir, "hello.txt");
+			var testFileRename = path.join(dir, "hEllO.txt");
+			testHelper.dir(dir);
+			testHelper.file(testFile);
+
+			let afterRename = false;
+
+			w.on("aggregated", function(changes, removals) {
+				if (!afterRename) return;
+				const files = w.getTimeInfoEntries();
+				w.close();
+
+				for (const file of files.keys()) {
+					if (file.endsWith("hello.txt") && files.get(file)) {
+						return done(new Error(`Renamed file was still in timeInfoEntries`));
+					}
+				}
+				return done();
+			});
+
+			w.watch([path.join(fixtures, testFile)], [], 0);
+
+			testHelper.tick(function() {
+				afterRename = true;
+				testHelper.rename(testFile, testFileRename);
+			});
+		});
 	});
 }

--- a/test/Casing.js
+++ b/test/Casing.js
@@ -55,12 +55,11 @@ if (fsIsCaseInsensitive) {
 			testHelper.dir(dir);
 			testHelper.file(testFile);
 
-			let afterRename = false;
-
 			w.on("aggregated", function(changes, removals) {
-				if (!afterRename) return;
 				const files = w.getTimeInfoEntries();
 				w.close();
+
+				changes.has(path.join(fixtures, dir)).should.be.eql(true);
 
 				for (const file of files.keys()) {
 					if (file.endsWith("hello.txt")) {
@@ -70,11 +69,12 @@ if (fsIsCaseInsensitive) {
 				return done();
 			});
 
-			w.watch([], [path.join(fixtures, "case-rename")], 0);
-
 			testHelper.tick(function() {
-				afterRename = true;
-				testHelper.rename(testFile, testFileRename);
+				w.watch([], [path.join(fixtures, "case-rename")]);
+
+				testHelper.tick(function() {
+					testHelper.rename(testFile, testFileRename);
+				});
 			});
 		});
 
@@ -88,12 +88,12 @@ if (fsIsCaseInsensitive) {
 			testHelper.dir(dir);
 			testHelper.file(testFile);
 
-			let afterRename = false;
-
 			w.on("aggregated", function(changes, removals) {
-				if (!afterRename) return;
 				const files = w.getTimeInfoEntries();
 				w.close();
+
+				changes.has(path.join(fixtures, testFileRename)).should.be.eql(true);
+				removals.has(path.join(fixtures, testFileRename)).should.be.eql(false);
 
 				for (const file of files.keys()) {
 					if (file.endsWith("hello.txt") && files.get(file)) {
@@ -103,11 +103,15 @@ if (fsIsCaseInsensitive) {
 				return done();
 			});
 
-			w.watch([path.join(fixtures, testFile)], [], 0);
-
 			testHelper.tick(function() {
-				afterRename = true;
-				testHelper.rename(testFile, testFileRename);
+				w.watch({
+					files: [path.join(fixtures, testFile)],
+					missing: [path.join(fixtures, testFileRename)]
+				});
+
+				testHelper.tick(function() {
+					testHelper.rename(testFile, testFileRename);
+				});
 			});
 		});
 	});

--- a/test/helpers/TestHelper.js
+++ b/test/helpers/TestHelper.js
@@ -68,6 +68,10 @@ TestHelper.prototype.dir = function dir(name) {
 	fs.mkdirSync(path.join(this.testdir, name));
 };
 
+TestHelper.prototype.rename = function rename(orig, dest) {
+	fs.renameSync(path.join(this.testdir, orig), path.join(this.testdir, dest));
+};
+
 TestHelper.prototype.file = function file(name) {
 	fs.writeFileSync(path.join(this.testdir, name), Math.random() + "", "utf-8");
 };


### PR DESCRIPTION
As noticed in https://github.com/zeit/next.js/pull/10351 when a filename's casing is changed both variants of the filename are reported from `getTimeInfoEntries`. This makes users unable rely on `getTimeInfoEntries` as a safe source of truth on case insensitive file systems.

This PR attempts to correct this by when an event is triggered for a file that is already in the watcher's files it re-checks that the file is still present with exact casing by doing a `readdir` on the directory the file resides in.

The added test cases were tested and previously failing on:

- MacOS 10.14.6 (node: v12.14.1)
- Windows 10 Pro 1809 (node: v10.15.3)

I also tested against the added test case in https://github.com/zeit/next.js/pull/10351 to double check this has the expected behavior.
