### PR TITLE
Minor typographical fix

### DIFF
--- a/lib/DirectoryWatcher.js
+++ b/lib/DirectoryWatcher.js
@@ -211,8 +211,8 @@ class DirectoryWatcher extends EventEmitter {
 			const count = this.filesWithoutCase.get(key);
 			this.filesWithoutCase.set(key, (count || 0) + 1);
 			if (count !== undefined) {
-				// There is already a file with case-insenstive-equal name
-				// On a case-insenstive filesystem we may miss the renaming
+				// There is already a file with case-insensitive-equal name
+				// On a case-insensitive filesystem we may miss the renaming
 				// when only casing is changed.
 				// To be sure that our information is correct
 				// we trigger a rescan here


### PR DESCRIPTION
`insenstive` -> `insensitive`
Follow up of #143