### PR TITLE
Update Chokidar to the new minor version that fixes the prototype pollution vulnerability through minmimist

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "should": "^8.3.1"
   },
   "dependencies": {
-    "chokidar": "^2.0.2",
+    "chokidar": "^2.1.8",
     "graceful-fs": "^4.1.2",
     "neo-async": "^2.5.0"
   }


### PR DESCRIPTION
https://npmjs.com/advisories/1179

Chokidar `2.0.5` does not exist yet but there's a PR to cascade this fix down: https://github.com/paulmillr/chokidar/pull/993