### PR TITLE
Merge watchers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,20 +9,20 @@ stages:
 matrix:
   include:
     - os: linux
-      node_js: "12"
+      node_js: "14"
       stage: basic
     - os: osx
-      node_js: "12"
+      node_js: "14"
       stage: basic
     - os: linux
-      node_js: "12"
+      node_js: "14"
       env: WATCHPACK_POLLING=200
       stage: advanced
     - os: linux
-      node_js: "13"
+      node_js: "12"
       stage: advanced
     - os: linux
-      node_js: "13"
+      node_js: "12"
       env: WATCHPACK_POLLING=200
       stage: advanced
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ matrix:
     - os: osx
       node_js: "14"
       stage: basic
+    - os: osx
+      node_js: "14"
+      env: WATCHPACK_WATCHER_LIMIT=1
+      stage: advanced
     - os: linux
       node_js: "14"
       env: WATCHPACK_POLLING=200

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ cache:
 # what combinations to test
 environment:
   matrix:
-    - nodejs_version: 13
+    - nodejs_version: 14
     - nodejs_version: 12
     - nodejs_version: 10
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,8 +5,8 @@ jobs:
     strategy:
       maxParallel: 3
       matrix:
-        node-13:
-          node_version: ^13.0.0
+        node-14:
+          node_version: ^14.0.0
         node-12:
           node_version: ^12.4.0
         node-10:
@@ -42,8 +42,8 @@ jobs:
     strategy:
       maxParallel: 3
       matrix:
-        node-13:
-          node_version: ^13.0.0
+        node-14:
+          node_version: ^14.0.0
         node-12:
           node_version: ^12.4.0
         node-10:
@@ -79,8 +79,8 @@ jobs:
     strategy:
       maxParallel: 3
       matrix:
-        node-13:
-          node_version: ^13.0.0
+        node-14:
+          node_version: ^14.0.0
         node-12:
           node_version: ^12.4.0
         node-10:

--- a/lib/DirectoryWatcher.js
+++ b/lib/DirectoryWatcher.js
@@ -8,6 +8,8 @@ const EventEmitter = require("events").EventEmitter;
 const fs = require("graceful-fs");
 const path = require("path");
 
+const watchEventSource = require("./watchEventSource");
+
 const EXISTANCE_ONLY_TIME_ENTRY = Object.freeze({});
 
 let FS_ACCURACY = 1000;
@@ -115,7 +117,7 @@ class DirectoryWatcher extends EventEmitter {
 				if (IS_OSX) {
 					this.watchInParentDirectory();
 				}
-				this.watcher = fs.watch(this.path);
+				this.watcher = watchEventSource.watch(this.path);
 				this.watcher.on("change", this.onWatchEvent.bind(this));
 				this.watcher.on("error", this.onWatcherError.bind(this));
 			}

--- a/lib/DirectoryWatcher.js
+++ b/lib/DirectoryWatcher.js
@@ -79,6 +79,7 @@ class DirectoryWatcher extends EventEmitter {
 				: options.poll
 				? 5007
 				: false;
+		this.timeout = undefined;
 		this.initialScanRemoved = new Set();
 		this.initialScanFinished = undefined;
 		/** @type {Map<string, Set<Watcher>>} */
@@ -104,13 +105,12 @@ class DirectoryWatcher extends EventEmitter {
 	createWatcher() {
 		try {
 			if (this.polledWatching) {
-				// Poll for changes
-				const interval = setInterval(() => {
-					this.doScan(false);
-				}, this.polledWatching);
 				this.watcher = {
 					close: () => {
-						clearInterval(interval);
+						if (this.timeout) {
+							clearTimeout(this.timeout);
+							this.timeout = undefined;
+						}
 					}
 				};
 			} else {
@@ -466,6 +466,16 @@ class DirectoryWatcher extends EventEmitter {
 		if (err) {
 			console.error("Watchpack Error (initial scan): " + err);
 		}
+		this.onScanFinished();
+	}
+
+	onScanFinished() {
+		if (this.polledWatching) {
+			this.timeout = setTimeout(() => {
+				if (this.closed) return;
+				this.doScan(false);
+			}, this.polledWatching);
+		}
 	}
 
 	onDirectoryRemoved(reason) {
@@ -528,6 +538,10 @@ class DirectoryWatcher extends EventEmitter {
 			return;
 		}
 		this.scanning = true;
+		if (this.timeout) {
+			clearTimeout(this.timeout);
+			this.timeout = undefined;
+		}
 		process.nextTick(() => {
 			if (this.closed) return;
 			fs.readdir(this.path, (err, items) => {
@@ -606,6 +620,7 @@ class DirectoryWatcher extends EventEmitter {
 						this.doScan(this.scanAgainInitial);
 					} else {
 						this.scanning = false;
+						this.onScanFinished();
 					}
 				});
 				for (const itemPath of itemPaths) {

--- a/lib/DirectoryWatcher.js
+++ b/lib/DirectoryWatcher.js
@@ -526,124 +526,127 @@ class DirectoryWatcher extends EventEmitter {
 			return;
 		}
 		this.scanning = true;
-		fs.readdir(this.path, (err, items) => {
+		process.nextTick(() => {
 			if (this.closed) return;
-			if (err) {
-				if (err.code === "ENOENT" || err.code === "EPERM") {
-					this.onDirectoryRemoved("scan readdir failed");
-				} else {
-					this.onScanError(err);
-				}
-				this.initialScan = false;
-				this.initialScanFinished = Date.now();
-				if (initial) {
-					for (const watchers of this.watchers.values()) {
-						for (const watcher of watchers) {
-							if (watcher.checkStartTime(this.initialScanFinished, false)) {
-								watcher.emit(
-									"initial-missing",
-									"scan (parent directory missing in initial scan)"
-								);
-							}
-						}
-					}
-				}
-				if (this.scanAgain) {
-					this.scanAgain = false;
-					this.doScan(this.scanAgainInitial);
-				} else {
-					this.scanning = false;
-				}
-				return;
-			}
-			const itemPaths = new Set(
-				items.map(item => path.join(this.path, item.normalize("NFC")))
-			);
-			for (const file of this.files.keys()) {
-				if (!itemPaths.has(file)) {
-					this.setMissing(file, initial, "scan (missing)");
-				}
-			}
-			for (const directory of this.directories.keys()) {
-				if (!itemPaths.has(directory)) {
-					this.setMissing(directory, initial, "scan (missing)");
-				}
-			}
-			if (this.scanAgain) {
-				// Early repeat of scan
-				this.scanAgain = false;
-				this.doScan(initial);
-				return;
-			}
-			const itemFinished = needCalls(itemPaths.size + 1, () => {
+			fs.readdir(this.path, (err, items) => {
 				if (this.closed) return;
-				this.initialScan = false;
-				this.initialScanRemoved = null;
-				this.initialScanFinished = Date.now();
-				if (initial) {
-					const missingWatchers = new Map(this.watchers);
-					missingWatchers.delete(withoutCase(this.path));
-					for (const item of itemPaths) {
-						missingWatchers.delete(withoutCase(item));
+				if (err) {
+					if (err.code === "ENOENT" || err.code === "EPERM") {
+						this.onDirectoryRemoved("scan readdir failed");
+					} else {
+						this.onScanError(err);
 					}
-					for (const watchers of missingWatchers.values()) {
-						for (const watcher of watchers) {
-							if (watcher.checkStartTime(this.initialScanFinished, false)) {
-								watcher.emit(
-									"initial-missing",
-									"scan (missing in initial scan)"
-								);
+					this.initialScan = false;
+					this.initialScanFinished = Date.now();
+					if (initial) {
+						for (const watchers of this.watchers.values()) {
+							for (const watcher of watchers) {
+								if (watcher.checkStartTime(this.initialScanFinished, false)) {
+									watcher.emit(
+										"initial-missing",
+										"scan (parent directory missing in initial scan)"
+									);
+								}
 							}
 						}
 					}
+					if (this.scanAgain) {
+						this.scanAgain = false;
+						this.doScan(this.scanAgainInitial);
+					} else {
+						this.scanning = false;
+					}
+					return;
+				}
+				const itemPaths = new Set(
+					items.map(item => path.join(this.path, item.normalize("NFC")))
+				);
+				for (const file of this.files.keys()) {
+					if (!itemPaths.has(file)) {
+						this.setMissing(file, initial, "scan (missing)");
+					}
+				}
+				for (const directory of this.directories.keys()) {
+					if (!itemPaths.has(directory)) {
+						this.setMissing(directory, initial, "scan (missing)");
+					}
 				}
 				if (this.scanAgain) {
+					// Early repeat of scan
 					this.scanAgain = false;
-					this.doScan(this.scanAgainInitial);
-				} else {
-					this.scanning = false;
+					this.doScan(initial);
+					return;
 				}
-			});
-			for (const itemPath of itemPaths) {
-				fs.lstat(itemPath, (err2, stats) => {
+				const itemFinished = needCalls(itemPaths.size + 1, () => {
 					if (this.closed) return;
-					if (err2) {
-						if (
-							err2.code === "ENOENT" ||
-							err2.code === "EPERM" ||
-							err2.code === "EBUSY"
-						) {
-							this.setMissing(itemPath, initial, "scan (" + err2.code + ")");
-						} else {
-							this.onScanError(err2);
+					this.initialScan = false;
+					this.initialScanRemoved = null;
+					this.initialScanFinished = Date.now();
+					if (initial) {
+						const missingWatchers = new Map(this.watchers);
+						missingWatchers.delete(withoutCase(this.path));
+						for (const item of itemPaths) {
+							missingWatchers.delete(withoutCase(item));
 						}
-						itemFinished();
-						return;
+						for (const watchers of missingWatchers.values()) {
+							for (const watcher of watchers) {
+								if (watcher.checkStartTime(this.initialScanFinished, false)) {
+									watcher.emit(
+										"initial-missing",
+										"scan (missing in initial scan)"
+									);
+								}
+							}
+						}
 					}
-					if (stats.isFile() || stats.isSymbolicLink()) {
-						if (stats.mtime) {
-							ensureFsAccuracy(stats.mtime);
+					if (this.scanAgain) {
+						this.scanAgain = false;
+						this.doScan(this.scanAgainInitial);
+					} else {
+						this.scanning = false;
+					}
+				});
+				for (const itemPath of itemPaths) {
+					fs.lstat(itemPath, (err2, stats) => {
+						if (this.closed) return;
+						if (err2) {
+							if (
+								err2.code === "ENOENT" ||
+								err2.code === "EPERM" ||
+								err2.code === "EBUSY"
+							) {
+								this.setMissing(itemPath, initial, "scan (" + err2.code + ")");
+							} else {
+								this.onScanError(err2);
+							}
+							itemFinished();
+							return;
 						}
-						this.setFileTime(
-							itemPath,
-							+stats.mtime || +stats.ctime || 1,
-							initial,
-							true,
-							"scan (file)"
-						);
-					} else if (stats.isDirectory()) {
-						if (!initial || !this.directories.has(itemPath))
-							this.setDirectory(
+						if (stats.isFile() || stats.isSymbolicLink()) {
+							if (stats.mtime) {
+								ensureFsAccuracy(stats.mtime);
+							}
+							this.setFileTime(
 								itemPath,
 								+stats.mtime || +stats.ctime || 1,
 								initial,
-								"scan (dir)"
+								true,
+								"scan (file)"
 							);
-					}
-					itemFinished();
-				});
-			}
-			itemFinished();
+						} else if (stats.isDirectory()) {
+							if (!initial || !this.directories.has(itemPath))
+								this.setDirectory(
+									itemPath,
+									+stats.mtime || +stats.ctime || 1,
+									initial,
+									"scan (dir)"
+								);
+						}
+						itemFinished();
+					});
+				}
+				itemFinished();
+			});
 		});
 	}
 

--- a/lib/getWatcherManager.js
+++ b/lib/getWatcherManager.js
@@ -38,6 +38,10 @@ class WatcherManager {
 }
 
 const watcherManagers = new WeakMap();
+/**
+ * @param {object} options options
+ * @returns {WatcherManager} the watcher manager
+ */
 module.exports = options => {
 	const watcherManager = watcherManagers.get(options);
 	if (watcherManager !== undefined) return watcherManager;

--- a/lib/reducePlan.js
+++ b/lib/reducePlan.js
@@ -1,0 +1,126 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+"use strict";
+
+const path = require("path");
+
+/**
+ * @template T
+ * @typedef {Object} TreeNode
+ * @property {string} filePath
+ * @property {TreeNode} parent
+ * @property {TreeNode[]} children
+ * @property {number} entries
+ * @property {boolean} active
+ * @property {T[] | T | undefined} value
+ */
+
+/**
+ * @template T
+ * @param {Map<string, T[] | T} plan
+ * @param {number} limit
+ * @returns {Map<string, Map<T, string>>} the new plan
+ */
+module.exports = (plan, limit) => {
+	const treeMap = new Map();
+	// Convert to tree
+	for (const [filePath, value] of plan) {
+		treeMap.set(filePath, {
+			filePath,
+			parent: undefined,
+			children: undefined,
+			entries: 1,
+			active: true,
+			value
+		});
+	}
+	let currentCount = treeMap.size;
+	// Create parents and calculate sum of entries
+	for (const node of treeMap.values()) {
+		const parentPath = path.dirname(node.filePath);
+		if (parentPath !== node.filePath) {
+			let parent = treeMap.get(parentPath);
+			if (parent === undefined) {
+				parent = {
+					filePath: parentPath,
+					parent: undefined,
+					children: [node],
+					entries: node.entries,
+					active: false,
+					value: undefined
+				};
+				treeMap.set(parentPath, parent);
+			} else {
+				if (parent.children === undefined) {
+					parent.children = [node];
+				} else {
+					parent.children.push(node);
+				}
+				do {
+					parent.entries += node.entries;
+					parent = parent.parent;
+				} while (parent);
+			}
+		}
+	}
+	// Reduce until limit reached
+	while (currentCount > limit) {
+		// Select node that helps reaching the limit most effectively without overmerging
+		const overLimit = limit - currentCount;
+		let bestNode = undefined;
+		let bestCost = Infinity;
+		for (const node of treeMap.values()) {
+			if (node.entries <= 1 || !node.children) continue;
+			if (node.children.length <= 1) continue;
+			const cost = Math.abs(overLimit - node.entries + 1);
+			if (cost < bestCost) {
+				bestNode = node;
+				bestCost = cost;
+			}
+		}
+		if (!bestNode) break;
+		// Merge all children
+		const reduction = bestNode.entries - 1;
+		bestNode.active = true;
+		bestNode.entries = 1;
+		currentCount -= reduction;
+		let parent = bestNode.parent;
+		while (parent) {
+			parent.entries -= reduction;
+			parent = parent.parent;
+		}
+		const queue = new Set(bestNode.children);
+		for (const node of queue) {
+			node.active = false;
+			node.entries = 0;
+			if (node.children) {
+				for (const child of node.children) queue.add(child);
+			}
+		}
+	}
+	// Write down new plan
+	const newPlan = new Map();
+	for (const node of treeMap.values()) {
+		if (!node.active) continue;
+		const map = new Map();
+		const queue = new Set([node]);
+		for (const node of queue) {
+			if (node.value) {
+				if (Array.isArray(node.value)) {
+					for (const item of node.value) {
+						map.set(item, node.filePath);
+					}
+				} else {
+					map.set(node.value, node.filePath);
+				}
+			}
+			if (node.children) {
+				for (const child of node.children) queue.add(child);
+			}
+		}
+		newPlan.set(node.filePath, map);
+	}
+	return newPlan;
+};

--- a/lib/reducePlan.js
+++ b/lib/reducePlan.js
@@ -74,7 +74,13 @@ module.exports = (plan, limit) => {
 		for (const node of treeMap.values()) {
 			if (node.entries <= 1 || !node.children) continue;
 			if (node.children.length <= 1) continue;
-			const cost = Math.abs(overLimit - node.entries + 1);
+			// Try to select the node with has just a bit more entries than we need to reduce
+			// When just a bit more is over 30% over the limit,
+			// also consider just a bit less entries then we need to reduce
+			const cost =
+				node.entries - 1 >= overLimit
+					? node.entries - 1 - overLimit
+					: overLimit - node.entries + 1 + limit * 0.3;
 			if (cost < bestCost) {
 				bestNode = node;
 				bestCost = cost;

--- a/lib/watchEventSource.js
+++ b/lib/watchEventSource.js
@@ -254,7 +254,7 @@ const execute = () => {
 			} else {
 				for (const filePath of filePaths) {
 					const w = createDirectWatcher(filePath);
-					for (const watcher of entry) {
+					for (const watcher of entry.keys()) {
 						const old = underlyingWatcher.get(watcher);
 						if (old === w) continue;
 						w.add(watcher);

--- a/lib/watchEventSource.js
+++ b/lib/watchEventSource.js
@@ -1,0 +1,300 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const { EventEmitter } = require("events");
+const reducePlan = require("./reducePlan");
+
+const IS_OSX = require("os").platform() === "darwin";
+const IS_WIN = require("os").platform() === "win32";
+const SUPPORTS_RECURSIVE_WATCHING = IS_OSX || IS_WIN;
+
+const watcherLimit =
+	+process.env.WATCHPACK_WATCHER_LIMIT || (IS_OSX ? 2000 : 10000);
+
+let isBatch = false;
+let watcherCount = 0;
+
+/** @type {Map<Watcher, string>} */
+const pendingWatchers = new Map();
+
+/** @type {Map<string, RecursiveWatcher>} */
+const recursiveWatchers = new Map();
+
+/** @type {Map<string, DirectWatcher>} */
+const directWatchers = new Map();
+
+/** @type {Map<Watcher, RecursiveWatcher | DirectWatcher>} */
+const underlyingWatcher = new Map();
+
+class DirectWatcher {
+	constructor(filePath) {
+		this.filePath = filePath;
+		this.watchers = new Set();
+		this.watcher = undefined;
+		try {
+			const watcher = fs.watch(filePath);
+			this.watcher = watcher;
+			watcher.on("change", (type, filename) => {
+				for (const w of this.watchers) {
+					w.emit("change", type, filename);
+				}
+			});
+			watcher.on("error", error => {
+				for (const w of this.watchers) {
+					w.emit("error", error);
+				}
+			});
+		} catch (err) {
+			process.nextTick(() => {
+				for (const w of this.watchers) {
+					w.emit("error", err);
+				}
+			});
+		}
+		watcherCount++;
+	}
+
+	add(watcher) {
+		underlyingWatcher.set(watcher, this);
+		this.watchers.add(watcher);
+	}
+
+	remove(watcher) {
+		this.watchers.delete(watcher);
+		if (this.watchers.size === 0) {
+			directWatchers.delete(this.filePath);
+			watcherCount--;
+			if (this.watcher) this.watcher.close();
+		}
+	}
+
+	getWatchers() {
+		return this.watchers;
+	}
+}
+
+class RecursiveWatcher {
+	constructor(rootPath) {
+		this.rootPath = rootPath;
+		this.mapWatcherToPath = new Map();
+		this.mapPathToWatchers = new Map();
+		this.watcher = undefined;
+		try {
+			const watcher = fs.watch(rootPath, {
+				recursive: true
+			});
+			this.watcher = watcher;
+			watcher.on("change", (type, filename) => {
+				if (!filename) {
+					for (const w of this.mapWatcherToPath.keys()) {
+						w.emit("change", type);
+					}
+				} else {
+					const dir = path.dirname(filename);
+					const watchers = this.mapPathToWatchers.get(dir);
+					if (watchers === undefined) return;
+					for (const w of watchers) {
+						w.emit("change", type, path.basename(filename));
+					}
+				}
+			});
+			watcher.on("error", error => {
+				for (const w of this.mapWatcherToPath.keys()) {
+					w.emit("error", error);
+				}
+			});
+		} catch (err) {
+			process.nextTick(() => {
+				for (const w of this.mapWatcherToPath.keys()) {
+					w.emit("error", err);
+				}
+			});
+		}
+		watcherCount++;
+	}
+
+	add(filePath, watcher) {
+		underlyingWatcher.set(watcher, this);
+		const subpath = filePath.slice(this.rootPath.length + 1) || ".";
+		this.mapWatcherToPath.set(watcher, subpath);
+		const set = this.mapPathToWatchers.get(subpath);
+		if (set === undefined) {
+			const newSet = new Set();
+			newSet.add(watcher);
+			this.mapPathToWatchers.set(subpath, newSet);
+		} else {
+			set.add(watcher);
+		}
+	}
+
+	remove(watcher) {
+		const subpath = this.mapWatcherToPath.get(watcher);
+		if (!subpath) return;
+		this.mapWatcherToPath.delete(watcher);
+		const set = this.mapPathToWatchers.get(subpath);
+		set.delete(subpath);
+		if (set.size === 0) {
+			this.mapPathToWatchers.delete(subpath);
+		}
+		if (this.mapWatcherToPath.size === 0) {
+			recursiveWatchers.delete(this.rootPath);
+			watcherCount--;
+			if (this.watcher) this.watcher.close();
+		}
+	}
+
+	getWatchers() {
+		return this.mapWatcherToPath;
+	}
+}
+
+class Watcher extends EventEmitter {
+	close() {
+		if (pendingWatchers.has(this)) {
+			pendingWatchers.delete(this);
+			return;
+		}
+		const watcher = underlyingWatcher.get(this);
+		watcher.remove(this);
+		underlyingWatcher.delete(this);
+	}
+}
+
+const createDirectWatcher = filePath => {
+	const existing = directWatchers.get(filePath);
+	if (existing !== undefined) return existing;
+	const w = new DirectWatcher(filePath);
+	directWatchers.set(filePath, w);
+	return w;
+};
+
+const createRecursiveWatcher = rootPath => {
+	const existing = recursiveWatchers.get(rootPath);
+	if (existing !== undefined) return existing;
+	const w = new RecursiveWatcher(rootPath);
+	recursiveWatchers.set(rootPath, w);
+	return w;
+};
+
+const execute = () => {
+	/** @type {Map<string, Watcher[] | Watcher>} */
+	const map = new Map();
+	const addWatcher = (watcher, filePath) => {
+		const entry = map.get(filePath);
+		if (entry === undefined) {
+			map.set(filePath, watcher);
+		} else if (Array.isArray(entry)) {
+			entry.push(watcher);
+		} else {
+			map.set(filePath, [entry, watcher]);
+		}
+	};
+	for (const [watcher, filePath] of pendingWatchers) {
+		addWatcher(watcher, filePath);
+	}
+	pendingWatchers.clear();
+
+	// Fast case when we are not reaching the limit
+	if (!SUPPORTS_RECURSIVE_WATCHING || watcherLimit - watcherCount >= map.size) {
+		// Create watchers for all entries in the map
+		for (const [filePath, entry] of map) {
+			const w = createDirectWatcher(filePath);
+			if (Array.isArray(entry)) {
+				for (const item of entry) w.add(item);
+			} else {
+				w.add(entry);
+			}
+		}
+		return;
+	}
+
+	// Reconsider existing watchers to improving watch plan
+	for (const watcher of recursiveWatchers.values()) {
+		for (const [w, subpath] of watcher.getWatchers()) {
+			addWatcher(w, path.join(watcher.rootPath, subpath));
+		}
+	}
+	for (const watcher of directWatchers.values()) {
+		for (const w of watcher.getWatchers()) {
+			addWatcher(w, watcher.filePath);
+		}
+	}
+
+	// Merge map entries to keep watcher limit
+	// Create a 10% buffer to be able to enter fast case more often
+	const plan = reducePlan(map, watcherLimit * 0.9);
+
+	// Update watchers for all entries in the map
+	for (const [filePath, entry] of plan) {
+		if (entry.size === 1) {
+			for (const [watcher, filePath] of entry) {
+				const w = createDirectWatcher(filePath);
+				const old = underlyingWatcher.get(watcher);
+				if (old === w) continue;
+				w.add(watcher);
+				if (old !== undefined) old.remove(watcher);
+			}
+		} else {
+			const filePaths = new Set(entry.values());
+			if (filePaths.size > 1) {
+				const w = createRecursiveWatcher(filePath);
+				for (const [watcher, watcherPath] of entry) {
+					const old = underlyingWatcher.get(watcher);
+					if (old === w) continue;
+					w.add(watcherPath, watcher);
+					if (old !== undefined) old.remove(watcher);
+				}
+			} else {
+				for (const filePath of filePaths) {
+					const w = createDirectWatcher(filePath);
+					for (const watcher of entry) {
+						const old = underlyingWatcher.get(watcher);
+						if (old === w) continue;
+						w.add(watcher);
+						if (old !== undefined) old.remove(watcher);
+					}
+				}
+			}
+		}
+	}
+};
+
+exports.watch = filePath => {
+	const watcher = new Watcher();
+	// Find an existing watcher
+	const directWatcher = directWatchers.get(filePath);
+	if (directWatcher !== undefined) {
+		directWatcher.add(watcher);
+		return watcher;
+	}
+	let current = filePath;
+	for (;;) {
+		const recursiveWatcher = recursiveWatchers.get(current);
+		if (recursiveWatcher !== undefined) {
+			recursiveWatcher.add(filePath, watcher);
+			return watcher;
+		}
+		const parent = path.dirname(current);
+		if (parent === current) break;
+		current = parent;
+	}
+	// Queue up watcher for creation
+	pendingWatchers.set(watcher, filePath);
+	if (!isBatch) execute();
+	return watcher;
+};
+
+exports.batch = fn => {
+	isBatch = true;
+	try {
+		fn();
+	} finally {
+		isBatch = false;
+		execute();
+	}
+};

--- a/lib/watchEventSource.js
+++ b/lib/watchEventSource.js
@@ -81,7 +81,9 @@ class DirectWatcher {
 class RecursiveWatcher {
 	constructor(rootPath) {
 		this.rootPath = rootPath;
+		/** @type {Map<Watcher, string>} */
 		this.mapWatcherToPath = new Map();
+		/** @type {Map<string, Set<Watcher>>} */
 		this.mapPathToWatchers = new Map();
 		this.watcher = undefined;
 		try {
@@ -137,7 +139,7 @@ class RecursiveWatcher {
 		if (!subpath) return;
 		this.mapWatcherToPath.delete(watcher);
 		const set = this.mapPathToWatchers.get(subpath);
-		set.delete(subpath);
+		set.delete(watcher);
 		if (set.size === 0) {
 			this.mapPathToWatchers.delete(subpath);
 		}

--- a/lib/watchEventSource.js
+++ b/lib/watchEventSource.js
@@ -298,3 +298,7 @@ exports.batch = fn => {
 		execute();
 	}
 };
+
+exports.getNumberOfWatchers = () => {
+	return watcherCount;
+};

--- a/lib/watchpack.js
+++ b/lib/watchpack.js
@@ -8,6 +8,7 @@ const getWatcherManager = require("./getWatcherManager");
 const LinkResolver = require("./LinkResolver");
 const EventEmitter = require("events").EventEmitter;
 const globToRegExp = require("glob-to-regexp");
+const watchEventSource = require("./watchEventSource");
 
 let EXISTANCE_ONLY_TIME_ENTRY; // lazy required
 
@@ -70,7 +71,9 @@ class Watchpack extends EventEmitter {
 		this.options = options;
 		this.watcherOptions = cachedNormalizeOptions(options);
 		this.watcherManager = getWatcherManager(this.watcherOptions);
-		this.watchers = [];
+		this.fileWatchers = new Map();
+		this.directoryWatchers = new Map();
+		this.startTime = undefined;
 		this.paused = false;
 		this.aggregatedChanges = new Set();
 		this.aggregatedRemovals = new Set();
@@ -94,23 +97,30 @@ class Watchpack extends EventEmitter {
 			startTime = arg3;
 		}
 		this.paused = false;
-		const oldWatchers = this.watchers;
+		const oldFileWatchers = this.fileWatchers;
+		const oldDirectoryWatchers = this.directoryWatchers;
 		const ignored = this.watcherOptions.ignored;
 		const filter = ignored
 			? path => !ignored.test(path.replace(/\\/g, "/"))
 			: () => true;
-		this.watchers = [];
+		const addToMap = (map, key, item) => {
+			const list = map.get(key);
+			if (list === undefined) {
+				map.set(key, [item]);
+			} else {
+				list.push(item);
+			}
+		};
+		const fileWatchersNeeded = new Map();
+		const directoryWatchersNeeded = new Map();
+		const missingFiles = new Set();
 		if (this.watcherOptions.followSymlinks) {
 			const resolver = new LinkResolver();
 			for (const file of files) {
 				if (filter(file)) {
 					for (const innerFile of resolver.resolve(file)) {
 						if (file === innerFile || filter(innerFile)) {
-							const watcher = this._fileWatcher(
-								file,
-								this.watcherManager.watchFile(innerFile, startTime)
-							);
-							if (watcher) this.watchers.push(watcher);
+							addToMap(fileWatchersNeeded, innerFile, file);
 						}
 					}
 				}
@@ -119,11 +129,8 @@ class Watchpack extends EventEmitter {
 				if (filter(file)) {
 					for (const innerFile of resolver.resolve(file)) {
 						if (file === innerFile || filter(innerFile)) {
-							const watcher = this._missingWatcher(
-								file,
-								this.watcherManager.watchFile(innerFile, startTime)
-							);
-							if (watcher) this.watchers.push(watcher);
+							missingFiles.add(file);
+							addToMap(fileWatchersNeeded, innerFile, file);
 						}
 					}
 				}
@@ -133,13 +140,11 @@ class Watchpack extends EventEmitter {
 					let first = true;
 					for (const innerItem of resolver.resolve(dir)) {
 						if (filter(innerItem)) {
-							const watcher = this._dirWatcher(
-								dir,
-								first
-									? this.watcherManager.watchDirectory(innerItem, startTime)
-									: this.watcherManager.watchFile(innerItem, startTime)
+							addToMap(
+								first ? directoryWatchersNeeded : fileWatchersNeeded,
+								innerItem,
+								dir
 							);
-							if (watcher) this.watchers.push(watcher);
 						}
 						first = false;
 					}
@@ -148,40 +153,107 @@ class Watchpack extends EventEmitter {
 		} else {
 			for (const file of files) {
 				if (filter(file)) {
-					const watcher = this._fileWatcher(
-						file,
-						this.watcherManager.watchFile(file, startTime)
-					);
-					if (watcher) this.watchers.push(watcher);
+					addToMap(fileWatchersNeeded, file, file);
 				}
 			}
 			for (const file of missing) {
 				if (filter(file)) {
-					const watcher = this._missingWatcher(
-						file,
-						this.watcherManager.watchFile(file, startTime)
-					);
-					if (watcher) this.watchers.push(watcher);
+					missingFiles.add(file);
+					addToMap(fileWatchersNeeded, file, file);
 				}
 			}
 			for (const dir of directories) {
 				if (filter(dir)) {
-					const watcher = this._dirWatcher(
-						dir,
-						this.watcherManager.watchDirectory(dir, startTime)
-					);
-					if (watcher) this.watchers.push(watcher);
+					addToMap(directoryWatchersNeeded, dir, dir);
 				}
 			}
 		}
-		for (const w of oldWatchers) w.close();
+		const newFileWatchers = new Map();
+		const newDirectoryWatchers = new Map();
+		const setupFileWatcher = (watcher, key, files) => {
+			watcher.on("initial-missing", type => {
+				for (const file of files) {
+					if (!missingFiles.has(file)) this._onRemove(file, file, type);
+				}
+			});
+			watcher.on("change", (mtime, type) => {
+				for (const file of files) {
+					this._onChange(file, mtime, file, type);
+				}
+			});
+			watcher.on("remove", type => {
+				for (const file of files) {
+					this._onRemove(file, file, type);
+				}
+			});
+			newFileWatchers.set(key, watcher);
+		};
+		const setupDirectoryWatcher = (watcher, key, directories) => {
+			watcher.on("initial-missing", type => {
+				for (const item of directories) {
+					this._onRemove(item, item, type);
+				}
+			});
+			watcher.on("change", (file, mtime, type) => {
+				for (const item of directories) {
+					this._onChange(item, mtime, file, type);
+				}
+			});
+			watcher.on("remove", type => {
+				for (const item of directories) {
+					this._onRemove(item, item, type);
+				}
+			});
+			newDirectoryWatchers.set(key, watcher);
+		};
+		// Close unneeded old watchers
+		const fileWatchersToClose = [];
+		const directoryWatchersToClose = [];
+		for (const [key, w] of oldFileWatchers) {
+			if (!fileWatchersNeeded.has(key)) {
+				w.close();
+			} else {
+				fileWatchersToClose.push(w);
+			}
+		}
+		for (const [key, w] of oldDirectoryWatchers) {
+			if (!directoryWatchersNeeded.has(key)) {
+				w.close();
+			} else {
+				directoryWatchersToClose.push(w);
+			}
+		}
+		// Create new watchers and install handlers on these watchers
+		watchEventSource.batch(() => {
+			for (const [key, files] of fileWatchersNeeded) {
+				const watcher = this.watcherManager.watchFile(key, startTime);
+				if (watcher) {
+					setupFileWatcher(watcher, key, files);
+				}
+			}
+			for (const [key, directories] of directoryWatchersNeeded) {
+				const watcher = this.watcherManager.watchDirectory(key, startTime);
+				if (watcher) {
+					setupDirectoryWatcher(watcher, key, directories);
+				}
+			}
+		});
+		// Close old watchers
+		for (const w of fileWatchersToClose) w.close();
+		for (const w of directoryWatchersToClose) w.close();
+		// Store watchers
+		this.fileWatchers = newFileWatchers;
+		this.directoryWatchers = newDirectoryWatchers;
+		this.startTime = startTime;
 	}
 
 	close() {
 		this.paused = true;
 		if (this.aggregateTimeout) clearTimeout(this.aggregateTimeout);
-		for (const w of this.watchers) w.close();
-		this.watchers.length = 0;
+		for (const w of this.fileWatchers.values()) w.close();
+		for (const w of this.directoryWatchers.values()) w.close();
+		this.fileWatchers.clear();
+		this.directoryWatchers.clear();
 	}
 
 	pause() {
@@ -191,7 +263,8 @@ class Watchpack extends EventEmitter {
 
 	getTimes() {
 		const directoryWatchers = new Set();
-		addWatchersToSet(this.watchers, directoryWatchers);
+		addWatchersToSet(this.fileWatchers.values(), directoryWatchers);
+		addWatchersToSet(this.directoryWatchers.values(), directoryWatchers);
 		const obj = Object.create(null);
 		for (const w of directoryWatchers) {
 			const times = w.getTimes();
@@ -206,7 +279,8 @@ class Watchpack extends EventEmitter {
 				.EXISTANCE_ONLY_TIME_ENTRY;
 		}
 		const directoryWatchers = new Set();
-		addWatchersToSet(this.watchers, directoryWatchers);
+		addWatchersToSet(this.fileWatchers.values(), directoryWatchers);
+		addWatchersToSet(this.directoryWatchers.values(), directoryWatchers);
 		const map = new Map();
 		for (const w of directoryWatchers) {
 			const times = w.getTimeInfoEntries();

--- a/lib/watchpack.js
+++ b/lib/watchpack.js
@@ -13,6 +13,7 @@ const watchEventSource = require("./watchEventSource");
 let EXISTANCE_ONLY_TIME_ENTRY; // lazy required
 
 const EMPTY_ARRAY = [];
+const EMPTY_OPTIONS = {};
 
 function addWatchersToSet(watchers, set) {
 	for (const w of watchers) {
@@ -64,11 +65,12 @@ const cachedNormalizeOptions = options => {
 class Watchpack extends EventEmitter {
 	constructor(options) {
 		super();
-		if (!options) options = {};
-		if (typeof options.aggregateTimeout !== "number") {
-			options.aggregateTimeout = 200;
-		}
+		if (!options) options = EMPTY_OPTIONS;
 		this.options = options;
+		this.aggregateTimeout =
+			typeof options.aggregateTimeout === "number"
+				? options.aggregateTimeout
+				: 200;
 		this.watcherOptions = cachedNormalizeOptions(options);
 		this.watcherManager = getWatcherManager(this.watcherOptions);
 		this.fileWatchers = new Map();
@@ -77,7 +79,7 @@ class Watchpack extends EventEmitter {
 		this.paused = false;
 		this.aggregatedChanges = new Set();
 		this.aggregatedRemovals = new Set();
-		this.aggregateTimeout = 0;
+		this.aggregateTimer = undefined;
 		this._onTimeout = this._onTimeout.bind(this);
 	}
 
@@ -249,7 +251,7 @@ class Watchpack extends EventEmitter {
 
 	close() {
 		this.paused = true;
-		if (this.aggregateTimeout) clearTimeout(this.aggregateTimeout);
+		if (this.aggregateTimer) clearTimeout(this.aggregateTimer);
 		for (const w of this.fileWatchers.values()) w.close();
 		for (const w of this.directoryWatchers.values()) w.close();
 		this.fileWatchers.clear();
@@ -258,7 +260,7 @@ class Watchpack extends EventEmitter {
 
 	pause() {
 		this.paused = true;
-		if (this.aggregateTimeout) clearTimeout(this.aggregateTimeout);
+		if (this.aggregateTimer) clearTimeout(this.aggregateTimer);
 	}
 
 	getTimes() {
@@ -344,30 +346,24 @@ class Watchpack extends EventEmitter {
 		file = file || item;
 		if (this.paused) return;
 		this.emit("change", file, mtime, type);
-		if (this.aggregateTimeout) clearTimeout(this.aggregateTimeout);
+		if (this.aggregateTimer) clearTimeout(this.aggregateTimer);
 		this.aggregatedRemovals.delete(item);
 		this.aggregatedChanges.add(item);
-		this.aggregateTimeout = setTimeout(
-			this._onTimeout,
-			this.options.aggregateTimeout
-		);
+		this.aggregateTimer = setTimeout(this._onTimeout, this.aggregateTimeout);
 	}
 
 	_onRemove(item, file, type) {
 		file = file || item;
 		if (this.paused) return;
 		this.emit("remove", file, type);
-		if (this.aggregateTimeout) clearTimeout(this.aggregateTimeout);
+		if (this.aggregateTimer) clearTimeout(this.aggregateTimer);
 		this.aggregatedChanges.delete(item);
 		this.aggregatedRemovals.add(item);
-		this.aggregateTimeout = setTimeout(
-			this._onTimeout,
-			this.options.aggregateTimeout
-		);
+		this.aggregateTimer = setTimeout(this._onTimeout, this.aggregateTimeout);
 	}
 
 	_onTimeout() {
-		this.aggregateTimeout = 0;
+		this.aggregateTimer = undefined;
 		const changes = this.aggregatedChanges;
 		const removals = this.aggregatedRemovals;
 		this.aggregatedChanges = new Set();

--- a/test/ManyWatchers.js
+++ b/test/ManyWatchers.js
@@ -1,0 +1,41 @@
+/*globals describe it beforeEach afterEach */
+"use strict";
+
+require("should");
+const path = require("path");
+const TestHelper = require("./helpers/TestHelper");
+const Watchpack = require("../lib/watchpack");
+
+const fixtures = path.join(__dirname, "fixtures");
+const testHelper = new TestHelper(fixtures);
+
+describe("ManyWatchers", function() {
+	this.timeout(120000);
+	beforeEach(testHelper.before);
+	afterEach(testHelper.after);
+
+	it("should watch more than 4096 directories", done => {
+		const files = [];
+		for (let i = 0; i < 5000; i++) {
+			const dir = `${Math.floor(i / 100)}/${i % 100}`;
+			if (i % 100 === 0) testHelper.dir(`${Math.floor(i / 100)}`);
+			testHelper.dir(dir);
+			testHelper.file(`${dir}/file`);
+			files.push(path.join(fixtures, dir, "file"));
+		}
+		testHelper.tick(1000, () => {
+			const w = new Watchpack({
+				aggregateTimeout: 1000
+			});
+			w.on("aggregated", function(changes) {
+				Array.from(changes).should.be.eql([path.join(fixtures, "49/49/file")]);
+				w.close();
+				done();
+			});
+			w.watch({ files });
+			testHelper.tick(10000, () => {
+				testHelper.file("49/49/file");
+			});
+		});
+	});
+});

--- a/test/ManyWatchers.js
+++ b/test/ManyWatchers.js
@@ -25,10 +25,18 @@ describe("ManyWatchers", function() {
 				j >>= 1;
 			}
 			const dir = `${i & highBit}/${i & ~highBit}`;
-			if (i === highBit) testHelper.dir(`${i}`);
+			if (i === highBit) {
+				testHelper.dir(`${i}`);
+				testHelper.file(`${i}/file`);
+				files.push(path.join(fixtures, `${i}`, "file"));
+			}
 			testHelper.dir(dir);
 			testHelper.file(`${dir}/file`);
 			files.push(path.join(fixtures, dir, "file"));
+			if (i === highBit) {
+				testHelper.file(`${dir}/file2`);
+				files.push(path.join(fixtures, dir, "file2"));
+			}
 		}
 		testHelper.tick(1000, () => {
 			const w = new Watchpack({

--- a/test/ManyWatchers.js
+++ b/test/ManyWatchers.js
@@ -10,7 +10,7 @@ const fixtures = path.join(__dirname, "fixtures");
 const testHelper = new TestHelper(fixtures);
 
 describe("ManyWatchers", function() {
-	this.timeout(120000);
+	this.timeout(180000);
 	beforeEach(testHelper.before);
 	afterEach(testHelper.after);
 
@@ -32,6 +32,11 @@ describe("ManyWatchers", function() {
 				w.close();
 				done();
 			});
+			for (let i = 100; i < files.length; i += 987) {
+				for (let j = 0; j < files.length - i; j += 987) {
+					w.watch({ files: files.slice(j, j + i) });
+				}
+			}
 			w.watch({ files });
 			testHelper.tick(10000, () => {
 				testHelper.file("49/49/file");

--- a/test/Watchpack.js
+++ b/test/Watchpack.js
@@ -590,12 +590,11 @@ describe("Watchpack", function() {
 	});
 
 	it("should detect a single change to future timestamps", function(done) {
-		var w = new Watchpack({
+		const options = {
 			aggregateTimeout: 1000
-		});
-		var w2 = new Watchpack({
-			aggregateTimeout: 1000
-		});
+		};
+		var w = new Watchpack(options);
+		var w2 = new Watchpack(options);
 		w.on("change", function() {
 			throw new Error("should not report change event");
 		});
@@ -604,15 +603,41 @@ describe("Watchpack", function() {
 		});
 		testHelper.file("a");
 		testHelper.tick(400, function() {
-			w2.watch([path.join(fixtures, "a")], []);
+			w2.watch([path.join(fixtures, "a")], [], Date.now());
 			testHelper.tick(1000, function() {
 				// wait for initial scan
 				testHelper.mtime("a", Date.now() + 1000000);
 				testHelper.tick(400, function() {
-					w.watch([path.join(fixtures, "a")], []);
+					w.watch([path.join(fixtures, "a")], [], Date.now());
 					testHelper.tick(1000, function() {
 						w2.close();
 						w.close();
+						done();
+					});
+				});
+			});
+		});
+	});
+
+	it("should create different watchers for different options", function(done) {
+		var w = new Watchpack({
+			aggregateTimeout: 1000
+		});
+		var w2 = new Watchpack({
+			aggregateTimeout: 1000
+		});
+		testHelper.file("a");
+		testHelper.tick(400, function() {
+			w.watch([path.join(fixtures, "a")], [], Date.now());
+			w2.watch([path.join(fixtures, "a")], [], Date.now());
+			testHelper.tick(1000, function() {
+				testHelper.file("a");
+				testHelper.tick(400, function() {
+					testHelper.file("a");
+					testHelper.tick(1000, function() {
+						w2.close();
+						w.close();
+						console.log("test done");
 						done();
 					});
 				});

--- a/test/Watchpack.js
+++ b/test/Watchpack.js
@@ -637,7 +637,6 @@ describe("Watchpack", function() {
 					testHelper.tick(1000, function() {
 						w2.close();
 						w.close();
-						console.log("test done");
 						done();
 					});
 				});

--- a/test/helpers/TestHelper.js
+++ b/test/helpers/TestHelper.js
@@ -5,6 +5,8 @@ var path = require("path");
 var rimraf = require("rimraf");
 var writeFileAtomic = require("write-file-atomic");
 
+var watchEventSource = require("../../lib/watchEventSource");
+
 require("../../lib/getWatcherManager");
 var watcherManagerModule =
 	require.cache[require.resolve("../../lib/getWatcherManager")];
@@ -20,6 +22,7 @@ const checkAllWatcherClosed = () => {
 	for (const watcherManager of allWatcherManager) {
 		Array.from(watcherManager.directoryWatchers.keys()).should.be.eql([]);
 	}
+	watchEventSource.getNumberOfWatchers().should.be.eql(0);
 };
 
 function TestHelper(testdir) {


### PR DESCRIPTION
This adds an additional layer for os watchers, which take care of merging duplicate watchers and merging watchers into recursive watchers once the watcher limit has been reached.

* default watcher limit is 2000 on OSX and 10000 on other platforms
  * It's changeable via `WATCHPACK_WATCHER_LIMIT` environment variable
* only OSX and windows are enabled for recursive watching
  * watchers will be merged into recursive watchers
* Watcher creation is batched in the facade to allow to make the decision about merging with all info
* once the limit would be reached we make a new watch plan using recursive watchers
  * even existing watchers are reconsidered and possible migrated to the new watch plan
  * watchers are merged based on how to reach the limit most effectively, while merging the fewest amount of watchers
  * when creating a new plan we stay 10% below the limit to reduce how often we need to replan
* improve polling schedule to support high number of watchers
* update CI configurations

fixes #169