### PR TITLE
fix 'return' outside of function

### DIFF
--- a/lib/chokidar.js
+++ b/lib/chokidar.js
@@ -1,22 +1,13 @@
 var v3Err;
 try {
 	module.exports = require("chokidar");
-	return;
-} catch(e) {
+} catch (e) {
 	v3Err = e;
+	var v2Err;
+	try {
+		module.exports = require("watchpack-chokidar2");
+	} catch (e) {
+		v2Err = e;
+		throw new Error("No version of chokidar is available. Tried chokidar@2 or chokidar@3.\n" + "You could try to manually install any chokidar version.\n" + "chokidar@3: " + v3Err + "\n" + "chokidar@2: " + v2Err + "\n");
+	}
 }
-
-var v2Err;
-try {
-	module.exports = require("watchpack-chokidar2");
-	return;
-} catch(e) {
-	v2Err = e;
-}
-
-throw new Error(
-	"No version of chokidar is available. Tried chokidar@2 and chokidar@3.\n" +
-	"You could try to manually install any chokidar version.\n" +
-	"chokidar@3: " + v3Err + "\n" +
-	"chokidar@2: " + v2Err + "\n"
-)


### PR DESCRIPTION
I was trying to update the webpack 4 version for webpack-dev-server here https://github.com/webpack/webpack-dev-server/pull/2764, but the [CI failed](https://dev.azure.com/webpack/webpack-dev-server/_build/results?buildId=11617&view=logs&j=f6156d09-3ca2-5020-2542-36bb7d490f59&t=7484613e-4a7d-5f05-fc52-229def1c3c8f&l=35) because of some `'return' outside of function` errors [threw by jest](https://stackoverflow.com/questions/57789431/how-do-i-fix-return-outside-of-function-when-running-a-node-js-application). So I've update the chokidar file to fix it.

Also, there're errors like [`TypeError: DirectoryWatcher is not a constructor`](https://dev.azure.com/webpack/webpack-dev-server/_build/results?buildId=11617&view=logs&j=f6156d09-3ca2-5020-2542-36bb7d490f59&t=7484613e-4a7d-5f05-fc52-229def1c3c8f&l=63), I saw someone reported similar issue [here](https://github.com/webpack/watchpack/issues/118) before, not sure if they're same case, but mine can be fixed with this PR change in my test.