### PR TITLE
use process start time when checking nested directory changes

### DIFF
--- a/lib/DirectoryWatcher.js
+++ b/lib/DirectoryWatcher.js
@@ -12,6 +12,8 @@ const watchEventSource = require("./watchEventSource");
 
 const EXISTANCE_ONLY_TIME_ENTRY = Object.freeze({});
 
+const processStartTime = Date.now() - process.uptime() * 1000 - 1000;
+
 let FS_ACCURACY = 1000;
 
 const IS_OSX = require("os").platform() === "darwin";
@@ -278,7 +280,10 @@ class DirectoryWatcher extends EventEmitter {
 	}
 
 	createNestedWatcher(directoryPath) {
-		const watcher = this.watcherManager.watchDirectory(directoryPath, 1);
+		const watcher = this.watcherManager.watchDirectory(
+			directoryPath,
+			processStartTime
+		);
 		watcher.on("change", (filePath, mtime, type, initial) => {
 			this._cachedTimeInfoEntries = undefined;
 			this.forEachWatcher(this.path, w => {
@@ -500,7 +505,10 @@ class DirectoryWatcher extends EventEmitter {
 			// removing directories in the root directory is not supported
 			if (path.dirname(parentDir) === parentDir) return;
 
-			this.parentWatcher = this.watcherManager.watchFile(this.path, 1);
+			this.parentWatcher = this.watcherManager.watchFile(
+				this.path,
+				processStartTime
+			);
 			this.parentWatcher.on("change", (mtime, type) => {
 				if (this.closed) return;
 


### PR DESCRIPTION
I honestly still have no idea which conditions exactly triggered the issue. But it was reproduced consistently - the root watcher was triggered on a change to the output folder but then the recursive check found some deep folder where it decided to compare `mtime` to `1` and of course always thought the folder had changed.

I am running on Windows but some colleagues using Macs reported similar issue though I haven't tested if they encountered the same problem.

Even though there likely is a more proper fix possible somewhere, this seems as a safe change to mitigate it.