### PR TITLE
ignore data: urls

### DIFF
--- a/lib/watchpack.js
+++ b/lib/watchpack.js
@@ -102,9 +102,11 @@ class Watchpack extends EventEmitter {
 		const oldFileWatchers = this.fileWatchers;
 		const oldDirectoryWatchers = this.directoryWatchers;
 		const ignored = this.watcherOptions.ignored;
+		const isFileSystemPath = filePath => !filePath.startsWith("data:");
 		const filter = ignored
-			? path => !ignored.test(path.replace(/\\/g, "/"))
-			: () => true;
+			? path =>
+					isFileSystemPath(path) && !ignored.test(path.replace(/\\/g, "/"))
+			: isFileSystemPath;
 		const addToMap = (map, key, item) => {
 			const list = map.get(key);
 			if (list === undefined) {

--- a/test/Watchpack.js
+++ b/test/Watchpack.js
@@ -87,6 +87,30 @@ describe("Watchpack", function() {
 		});
 	});
 
+	it("should not watch data: urls", function(done) {
+		var w = new Watchpack({
+			aggregateTimeout: 300,
+		});
+		var changeEvents = 0;
+		var aggregatedEvents = 0;
+		w.on("change", () => {
+			changeEvents++;
+		});
+		w.on("aggregated", () => {
+			aggregatedEvents++;
+		});
+		w.watch(['data:text/javascript,'], []);
+		testHelper.tick(() => {
+			testHelper.tick(1000, () => {
+				changeEvents.should.be.eql(0);
+				aggregatedEvents.should.be.eql(0);
+				testHelper.getNumberOfWatchers().should.be.eql(0);
+				w.close();
+				done();
+			});
+		});
+	});
+
 	it("should watch multiple files", function(done) {
 		var w = new Watchpack({
 			aggregateTimeout: 1000


### PR DESCRIPTION
Adding data urls like `data:text/javascript,` causes invalid watchpack results as watchpack can't find those virtual files on the disk and will mark them as removed in `initial-missing`:

https://github.com/webpack/watchpack/blob/310cb277e391ca31be2873605ad22c34b572695f/lib/watchpack.js#L176-L180

This triggers a file change event which causes webpack-dev-server to run two initial compilations if a `data:` url is watched.

See also https://github.com/webpack/webpack/issues/12283