### PR TITLE
fix: adds ENOENT for non windows platforms in LinkResolver.

### DIFF
--- a/lib/LinkResolver.js
+++ b/lib/LinkResolver.js
@@ -7,9 +7,11 @@
 const fs = require("fs");
 const path = require("path");
 
-const EXPECTED_ERRORS = new Set(
-	process.platform === "win32" ? ["EINVAL", "ENOENT", "UNKNOWN"] : ["EINVAL"]
-);
+// macOS, Linux, and Windows all rely on these errors
+const EXPECTED_ERRORS = new Set(["EINVAL", "ENOENT"]);
+
+// On Windows there is also this error in some cases
+if (process.platform === "win32") EXPECTED_ERRORS.add("UNKNOWN");
 
 class LinkResolver {
 	constructor() {

--- a/test/LinkResolver.js
+++ b/test/LinkResolver.js
@@ -1,0 +1,13 @@
+/*globals describe it beforeEach afterEach */
+"use strict";
+
+const should = require("should");
+const LinkResolver = require("../lib/LinkResolver");
+
+describe("LinkResolver", () => {
+	it("should not throw when a path resolves with ENOENT", () => {
+		const resolver = new LinkResolver();
+		const result = resolver.resolve("/path/to/nonexistent/file/or/folder");
+		should.exist(result);
+	});
+});


### PR DESCRIPTION
Solves for use case where Webpack is running under Bazel
with iBazel. Heavily relies on symlinks set up in a certain way.

Essentially we don't want Webpack to follow symlinks, but we do want the watcher
to follow symlinks. In that setup, it causes an `ENOENT` which does not fall through in
watchpack under `darwin` as the platform (or linux for that matter). This fixes that case.

See https://github.com/bazelbuild/rules_nodejs/pull/2431

CC @sokra @gregmagolan @mrmeku