### PR TITLE
Allow function in `watchOptions.ignored`

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ var wp = new Watchpack({
 	// ignored: "string" - a glob pattern for files or folders that should not be watched
 	// ignored: ["string", "string"] - multiple glob patterns that should be ignored
 	// ignored: /regexp/ - a regular expression for files or folders that should not be watched
+	// ignored: (entry) => boolean - an arbirary function which must return truthy to ignore an entry
 	// All subdirectories are ignored too
 });
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ var wp = new Watchpack({
 	// ignored: ["string", "string"] - multiple glob patterns that should be ignored
 	// ignored: /regexp/ - a regular expression for files or folders that should not be watched
 	// ignored: (entry) => boolean - an arbirary function which must return truthy to ignore an entry
+	// For all cases expect the arbirary function the path will have path separator normalized to '/'.
 	// All subdirectories are ignored too
 });
 

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ var wp = new Watchpack({
 	// ignored: "string" - a glob pattern for files or folders that should not be watched
 	// ignored: ["string", "string"] - multiple glob patterns that should be ignored
 	// ignored: /regexp/ - a regular expression for files or folders that should not be watched
-	// ignored: (entry) => boolean - an arbirary function which must return truthy to ignore an entry
-	// For all cases expect the arbirary function the path will have path separator normalized to '/'.
+	// ignored: (entry) => boolean - an arbitrary function which must return truthy to ignore an entry
+	// For all cases expect the arbitrary function the path will have path separator normalized to '/'.
 	// All subdirectories are ignored too
 });
 

--- a/lib/DirectoryWatcher.js
+++ b/lib/DirectoryWatcher.js
@@ -71,7 +71,7 @@ class DirectoryWatcher extends EventEmitter {
 		this.directories = new Map();
 		this.lastWatchEvent = 0;
 		this.initialScan = true;
-		this.ignored = options.ignored;
+		this.ignored = options.ignored || (() => false);
 		this.nestedWatching = false;
 		this.polledWatching =
 			typeof options.poll === "number"
@@ -94,12 +94,6 @@ class DirectoryWatcher extends EventEmitter {
 
 		this.createWatcher();
 		this.doScan(true);
-	}
-
-	checkIgnore(path) {
-		if (!this.ignored) return false;
-		path = path.replace(/\\/g, "/");
-		return this.ignored.test(path);
 	}
 
 	createWatcher() {
@@ -178,7 +172,7 @@ class DirectoryWatcher extends EventEmitter {
 	setFileTime(filePath, mtime, initial, ignoreWhenEqual, type) {
 		const now = Date.now();
 
-		if (this.checkIgnore(filePath)) return;
+		if (this.ignored(filePath)) return;
 
 		const old = this.files.get(filePath);
 
@@ -237,7 +231,7 @@ class DirectoryWatcher extends EventEmitter {
 	}
 
 	setDirectory(directoryPath, birthtime, initial, type) {
-		if (this.checkIgnore(directoryPath)) return;
+		if (this.ignored(directoryPath)) return;
 		if (directoryPath === this.path) {
 			if (!initial) {
 				this.forEachWatcher(this.path, w =>
@@ -398,7 +392,7 @@ class DirectoryWatcher extends EventEmitter {
 		}
 
 		const filePath = path.join(this.path, filename);
-		if (this.checkIgnore(filePath)) return;
+		if (this.ignored(filePath)) return;
 
 		if (this._activeEvents.get(filename) === undefined) {
 			this._activeEvents.set(filename, false);

--- a/lib/watchpack.js
+++ b/lib/watchpack.js
@@ -31,13 +31,15 @@ const stringToRegexp = ignored => {
 	return matchingStart;
 };
 
-const ignoredToRegexp = ignored => {
+const ignoredToRegexpLike = ignored => {
 	if (Array.isArray(ignored)) {
 		return new RegExp(ignored.map(i => stringToRegexp(i)).join("|"));
 	} else if (typeof ignored === "string") {
 		return new RegExp(stringToRegexp(ignored));
 	} else if (ignored instanceof RegExp) {
 		return ignored;
+	} else if (ignored instanceof Function) {
+		return { test: ignored };
 	} else if (ignored) {
 		throw new Error(`Invalid option for 'ignored': ${ignored}`);
 	} else {
@@ -48,7 +50,7 @@ const ignoredToRegexp = ignored => {
 const normalizeOptions = options => {
 	return {
 		followSymlinks: !!options.followSymlinks,
-		ignored: ignoredToRegexp(options.ignored),
+		ignored: ignoredToRegexpLike(options.ignored),
 		poll: options.poll
 	};
 };

--- a/lib/watchpack.js
+++ b/lib/watchpack.js
@@ -31,26 +31,28 @@ const stringToRegexp = ignored => {
 	return matchingStart;
 };
 
-const ignoredToRegexpLike = ignored => {
+const ignoredToFunction = ignored => {
 	if (Array.isArray(ignored)) {
-		return new RegExp(ignored.map(i => stringToRegexp(i)).join("|"));
+		const regexp = new RegExp(ignored.map(i => stringToRegexp(i)).join("|"));
+		return x => regexp.test(x.replace(/\\/g, "/"));
 	} else if (typeof ignored === "string") {
-		return new RegExp(stringToRegexp(ignored));
+		const regexp = new RegExp(stringToRegexp(ignored));
+		return x => regexp.test(x.replace(/\\/g, "/"));
 	} else if (ignored instanceof RegExp) {
-		return ignored;
+		return x => ignored.test(x.replace(/\\/g, "/"));
 	} else if (ignored instanceof Function) {
-		return { test: ignored };
+		return ignored;
 	} else if (ignored) {
 		throw new Error(`Invalid option for 'ignored': ${ignored}`);
 	} else {
-		return undefined;
+		return () => false;
 	}
 };
 
 const normalizeOptions = options => {
 	return {
 		followSymlinks: !!options.followSymlinks,
-		ignored: ignoredToRegexpLike(options.ignored),
+		ignored: ignoredToFunction(options.ignored),
 		poll: options.poll
 	};
 };
@@ -104,9 +106,7 @@ class Watchpack extends EventEmitter {
 		const oldFileWatchers = this.fileWatchers;
 		const oldDirectoryWatchers = this.directoryWatchers;
 		const ignored = this.watcherOptions.ignored;
-		const filter = ignored
-			? path => !ignored.test(path.replace(/\\/g, "/"))
-			: () => true;
+		const filter = path => !ignored(path);
 		const addToMap = (map, key, item) => {
 			const list = map.get(key);
 			if (list === undefined) {

--- a/test/Watchpack.js
+++ b/test/Watchpack.js
@@ -118,6 +118,32 @@ describe("Watchpack", function() {
 		});
 	});
 
+	it("should not watch a single ignored file (function)", function(done) {
+		var w = new Watchpack({
+			aggregateTimeout: 300,
+			ignored: (entry) => entry.includes("a")
+		});
+		var changeEvents = 0;
+		var aggregatedEvents = 0;
+		w.on("change", () => {
+			changeEvents++;
+		});
+		w.on("aggregated", () => {
+			aggregatedEvents++;
+		});
+		w.watch([path.join(fixtures, "a")], []);
+		testHelper.tick(() => {
+			testHelper.file("a");
+			testHelper.tick(1000, () => {
+				changeEvents.should.be.eql(0);
+				aggregatedEvents.should.be.eql(0);
+				testHelper.getNumberOfWatchers().should.be.eql(0);
+				w.close();
+				done();
+			});
+		});
+	});
+
 	it("should watch multiple files", function(done) {
 		var w = new Watchpack({
 			aggregateTimeout: 1000


### PR DESCRIPTION
The globs are turned into regex's anyway, so seems like a pretty simple change. Have a webpack discussion thread on the topic as well where I suggest aligning `watchOptions.ignored` and `WatchIgnorePlugin`