### PR TITLE
Removes hard dependency on Chokiar 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
   "dependencies": {
     "graceful-fs": "^4.1.2",
     "neo-async": "^2.5.0",
-    "chokidar": "^3.4.1",
-    "watchpack-chokidar2": "^2.0.1"
+    "chokidar": "^3.4.1"
   }
 }


### PR DESCRIPTION
Removes hard dependency on Chokidar 2. This should enable a 1.7.6 release to satisfy anyone still having to wait to upgrade to Webpack 5 who also wants to resolve recent security issue (https://www.npmjs.com/advisories/1751)  with Chokidr 2

Satisfies #199 