### PR TITLE
test: fix instability in polling tests

### DIFF
--- a/test/helpers/TestHelper.js
+++ b/test/helpers/TestHelper.js
@@ -119,9 +119,11 @@ TestHelper.prototype.remove = function remove(name) {
 };
 
 TestHelper.prototype.tick = function tick(arg, fn) {
+	// if polling is set, ensure the tick is longer than the polling interval.
+	let defaultTick = (+process.env.WATCHPACK_POLLING || 100) + 10;
 	if (typeof arg === "function") {
 		fn = arg;
-		arg = 100;
+		arg = defaultTick;
 	}
 	setTimeout(function() {
 		fn();


### PR DESCRIPTION
Fix the instability in polling tests with pausing the watcher due to multiple ticks in the same polling interval.

This will cause the test passes of https://github.com/webpack/watchpack/pull/205 and https://github.com/webpack/watchpack/pull/197 to complete successfully.

cc @alexander-akait 