### PR TITLE
Respect FS_ACCURACY when determining if file is untouched

### DIFF
--- a/lib/DirectoryWatcher.js
+++ b/lib/DirectoryWatcher.js
@@ -12,7 +12,7 @@ const watchEventSource = require("./watchEventSource");
 
 const EXISTANCE_ONLY_TIME_ENTRY = Object.freeze({});
 
-let FS_ACCURACY = 1000;
+let FS_ACCURACY = 2000;
 
 const IS_OSX = require("os").platform() === "darwin";
 const WATCHPACK_POLLING = process.env.WATCHPACK_POLLING;
@@ -181,7 +181,7 @@ class DirectoryWatcher extends EventEmitter {
 			safeTime = now;
 			accuracy = 0;
 
-			if (old && old.timestamp === mtime && mtime + FS_ACCURACY < now - 1000) {
+			if (old && old.timestamp === mtime && mtime + FS_ACCURACY < now) {
 				// We are sure that mtime is untouched
 				// This can be caused by some file attribute change
 				// e. g. when access time has been changed
@@ -782,4 +782,5 @@ function ensureFsAccuracy(mtime) {
 	if (FS_ACCURACY > 1 && mtime % 1 !== 0) FS_ACCURACY = 1;
 	else if (FS_ACCURACY > 10 && mtime % 10 !== 0) FS_ACCURACY = 10;
 	else if (FS_ACCURACY > 100 && mtime % 100 !== 0) FS_ACCURACY = 100;
+	else if (FS_ACCURACY > 1000 && mtime % 1000 !== 0) FS_ACCURACY = 1000;
 }


### PR DESCRIPTION
Should resolve https://github.com/webpack/webpack/issues/15431

After noodling on the discussions there and looking at past similar work done (namely https://github.com/webpack/watchpack/commit/164007c891d796a4f5e3ff60fc461ca8c416542f), I think this is the best way to resolve that issue while still doing best-effort to respect file systems with lower mtime accuracy.

Right now, the `if` check I am changing has an arbitrary 1s, while everywhere else is properly using the FS_ACCURACY, which will get updated to higher resolution if possible.

I think this is the best we can do without adding an optional dep of `fsevents` (fwiw, for OSX, chokidar will either use fsevents, or fall back to polling)

```
mtime + FS_ACCURACY < now - 1000
=
mtime + FS_ACCURACY + 1000 < now
> replace 1000 with FS_ACCURACY
mtime + FS_ACCURACY + FS_ACCURACY < now
=
mtime + 2* FS_ACCURACY < now
```