### PR TITLE
fix: ignore the error that directoryPath is not a directory

### DIFF
--- a/lib/DirectoryWatcher.js
+++ b/lib/DirectoryWatcher.js
@@ -465,9 +465,9 @@ class DirectoryWatcher extends EventEmitter {
 
 	onScanError(err) {
 		if (err) {
-      if (err.code !== 'ENOTDIR') {
-        console.error("Watchpack Error (initial scan): " + err);
-      }
+			if (err.code !== "ENOTDIR") {
+				console.error("Watchpack Error (initial scan): " + err);
+			}
 		}
 		this.onScanFinished();
 	}

--- a/lib/DirectoryWatcher.js
+++ b/lib/DirectoryWatcher.js
@@ -465,7 +465,9 @@ class DirectoryWatcher extends EventEmitter {
 
 	onScanError(err) {
 		if (err) {
-			console.error("Watchpack Error (initial scan): " + err);
+      if (err.code !== 'ENOTDIR') {
+        console.error("Watchpack Error (initial scan): " + err);
+      }
 		}
 		this.onScanFinished();
 	}


### PR DESCRIPTION
The error is caused by a specific alias config of webpack, considering the following example:

```js
// webpack.config.js
module.exports = {
  resolve: {
    alias:  {
       "@/foo": ["src/foo/index", "src/foo"] 
     }
  }
}
```

With the above config, we will get a `DirectoryWatcher` watching `src/foo/index`. If you happen to have a `src/foo` file on your filesystem, you will see the error: 

```
Watchpack Error (initial scan): Error: ENOTDIR: not a directory, scandir '/Users/xx/demo/src/foo'
```

We could safely ignore the error of `ENOTDIR` in whatever cases.


Related Issues:
https://github.com/nuxt/bridge/issues/226