### PR TITLE
perf: limit the number of concurrently open file watchers on macOS

### DIFF
--- a/lib/watchEventSource.js
+++ b/lib/watchEventSource.js
@@ -13,8 +13,10 @@ const IS_OSX = require("os").platform() === "darwin";
 const IS_WIN = require("os").platform() === "win32";
 const SUPPORTS_RECURSIVE_WATCHING = IS_OSX || IS_WIN;
 
+// Use 20 for OSX to make `FSWatcher.close` faster
+// https://github.com/nodejs/node/issues/29949
 const watcherLimit =
-	+process.env.WATCHPACK_WATCHER_LIMIT || (IS_OSX ? 2000 : 10000);
+	+process.env.WATCHPACK_WATCHER_LIMIT || (IS_OSX ? 20 : 10000);
 
 const recursiveWatcherLogging = !!process.env
 	.WATCHPACK_RECURSIVE_WATCHER_LOGGING;

--- a/lib/watchEventSource.js
+++ b/lib/watchEventSource.js
@@ -368,3 +368,4 @@ exports.getNumberOfWatchers = () => {
 };
 
 exports.createHandleChangeEvent = createHandleChangeEvent;
+exports.watcherLimit = watcherLimit;

--- a/test/ManyWatchers.js
+++ b/test/ManyWatchers.js
@@ -81,7 +81,7 @@ describe("ManyWatchers", function() {
 	});
 
 	it("should set the watcher limit based on the platform", () => {
-		should.eql(
+		should.equal(
 			watchEventSource.watcherLimit,
 			require("os").platform() === "darwin" ? 20 : 10000
 		);

--- a/test/ManyWatchers.js
+++ b/test/ManyWatchers.js
@@ -6,6 +6,7 @@ const path = require("path");
 const TestHelper = require("./helpers/TestHelper");
 const Watchpack = require("../lib/watchpack");
 const watchEventSource = require("../lib/watchEventSource");
+const should = require("should");
 
 const fixtures = path.join(__dirname, "fixtures");
 const testHelper = new TestHelper(fixtures);
@@ -77,5 +78,12 @@ describe("ManyWatchers", function() {
 				testHelper.file("4096/900/file");
 			});
 		});
+	});
+
+	it("should set the watcher limit based on the platform", () => {
+		should.eql(
+			watchEventSource.watcherLimit,
+			require("os").platform() === "darwin" ? 20 : 10000
+		);
 	});
 });


### PR DESCRIPTION
Limit the number of concurrently open file watchers on macOS to 20 to make `FSWatcher.close` faster.

Related PRs:

- https://github.com/vercel/next.js/pull/51826
- https://github.com/vercel/next.js/pull/73741
- https://github.com/web-infra-dev/rspack/pull/5486 (We tried setting WATCHPACK_WATCHER_LIMIT by default in the Rspack CLI, but I found that this did not work because watchpack was loaded earlier than the WATCHPACK_WATCHER_LIMIT was set in the Rspack CLI)

Related issues:

- https://github.com/webpack/watchpack/issues/222
- https://github.com/nodejs/node/issues/29949