### PR TITLE
fix: ignore listening for the directory itself to be deleted

### DIFF
--- a/lib/watchEventSource.js
+++ b/lib/watchEventSource.js
@@ -34,6 +34,33 @@ const directWatchers = new Map();
 /** @type {Map<Watcher, RecursiveWatcher | DirectWatcher>} */
 const underlyingWatcher = new Map();
 
+function createEPERMError(filePath) {
+	const error = new Error(`Operation not permitted: ${filePath}`);
+	error.code = "EPERM";
+	return error;
+}
+
+function createHandleChangeEvent(watcher, filePath, handleChangeEvent) {
+	return (type, filename) => {
+		// TODO: After Node.js v22, fs.watch(dir) and deleting a dir will trigger the rename change event.
+		// Here we just ignore it and keep the same behavior as before v22
+		// https://github.com/libuv/libuv/pull/4376
+		if (
+			type === "rename" &&
+			path.isAbsolute(filename) &&
+			path.basename(filename) === path.basename(filePath)
+		) {
+			if (!IS_OSX) {
+				// Before v22, windows will throw EPERM error
+				watcher.emit("error", createEPERMError(filename));
+			}
+			// Before v22, macos nothing to do
+			return;
+		}
+		handleChangeEvent(type, filename);
+	};
+}
+
 class DirectWatcher {
 	constructor(filePath) {
 		this.filePath = filePath;
@@ -41,12 +68,18 @@ class DirectWatcher {
 		this.watcher = undefined;
 		try {
 			const watcher = fs.watch(filePath);
+
 			this.watcher = watcher;
-			watcher.on("change", (type, filename) => {
-				for (const w of this.watchers) {
-					w.emit("change", type, filename);
+			const handleChangeEvent = createHandleChangeEvent(
+				watcher,
+				filePath,
+				(type, filename) => {
+					for (const w of this.watchers) {
+						w.emit("change", type, filename);
+					}
 				}
-			});
+			);
+			watcher.on("change", handleChangeEvent);
 			watcher.on("error", error => {
 				for (const w of this.watchers) {
 					w.emit("error", error);
@@ -331,3 +364,5 @@ exports.batch = fn => {
 exports.getNumberOfWatchers = () => {
 	return watcherCount;
 };
+
+exports.createHandleChangeEvent = createHandleChangeEvent;

--- a/test/Assumption.js
+++ b/test/Assumption.js
@@ -8,10 +8,12 @@ var TestHelper = require("./helpers/TestHelper");
 
 var fixtures = path.join(__dirname, "fixtures");
 var testHelper = new TestHelper(fixtures);
+var { createHandleChangeEvent } = require("../lib/watchEventSource");
 
 const IS_OSX = require("os").platform() === "darwin";
 const IS_WIN = require("os").platform() === "win32";
 const SUPPORTS_RECURSIVE_WATCHING = IS_OSX || IS_WIN;
+
 
 describe("Assumption", function() {
 	this.timeout(10000);
@@ -319,10 +321,11 @@ describe("Assumption", function() {
 				));
 				let gotSelfRename = false;
 				let gotPermError = false;
-				watcher.on("change", function(type, filename) {
+				let handleChangeEvent = createHandleChangeEvent(watcher, path.join(fixtures, "watch-test-dir"), (type, filename) => {
 					if (type === "rename" && filename === "watch-test-dir")
 						gotSelfRename = true;
 				});
+				watcher.on("change", handleChangeEvent);
 				watcher.on("error", function(err) {
 					if (err && err.code === "EPERM") gotPermError = true;
 				});


### PR DESCRIPTION
After Node.js v22, fs.watch(dir) and deleting a dir will trigger the rename change event.
Here we just ignore it and keep the same behavior as before v22
https://github.com/libuv/libuv/pull/4376