### PR TITLE
fix: follow symlinks discovered inside watched real directories (#190)

### DIFF
--- a/benchmark/cases/watchpack-construction/index.bench.mjs
+++ b/benchmark/cases/watchpack-construction/index.bench.mjs
@@ -10,9 +10,17 @@
  *
  * `.close()` is invoked after every construction to keep the outer test
  * process from leaking timers even though no watchers have been attached.
+ *
+ * Each benchmark body constructs BATCH instances in a loop. A single
+ * construction is ~100 µs, so one instrumented iteration would be too short
+ * for CodSpeed simulation mode to measure with low variance — batching
+ * amortizes per-sample overhead (GC, JIT state, timer resolution) and
+ * stabilizes CI-reported numbers.
  */
 
 import Watchpack from "../../../lib/index.js";
+
+const BATCH = 100;
 
 const optionsNone = {};
 const optionsWithRegExp = { ignored: /node_modules|\.git/ };
@@ -35,30 +43,39 @@ const optionsWithLargeArray = {
 const optionsWithFn = { ignored: (path) => path.includes("node_modules") };
 
 /**
+ * @param {object} options watchpack options reused across the batch
+ */
+const run = (options) => {
+	for (let i = 0; i < BATCH; i++) {
+		new Watchpack(options).close();
+	}
+};
+
+/**
  * @param {import("tinybench").Bench} bench bench
  */
 export default function register(bench) {
 	bench.add("watchpack-construction: no ignored option", () => {
-		new Watchpack(optionsNone).close();
+		run(optionsNone);
 	});
 	bench.add("watchpack-construction: regex ignored", () => {
-		new Watchpack(optionsWithRegExp).close();
+		run(optionsWithRegExp);
 	});
 	bench.add("watchpack-construction: glob string ignored", () => {
-		new Watchpack(optionsWithString).close();
+		run(optionsWithString);
 	});
 	bench.add("watchpack-construction: array[2] ignored", () => {
-		new Watchpack(optionsWithSmallArray).close();
+		run(optionsWithSmallArray);
 	});
 	bench.add("watchpack-construction: array[10] ignored", () => {
-		new Watchpack(optionsWithLargeArray).close();
+		run(optionsWithLargeArray);
 	});
 	bench.add("watchpack-construction: function ignored", () => {
-		new Watchpack(optionsWithFn).close();
+		run(optionsWithFn);
 	});
 	bench.add("watchpack-construction: cached options (WeakMap hit)", () => {
 		// Same options object every iteration exercises the WeakMap cache
 		// installed on the options by `cachedNormalizeOptions`.
-		new Watchpack(optionsWithLargeArray).close();
+		run(optionsWithLargeArray);
 	});
 }

--- a/lib/DirectoryWatcher.js
+++ b/lib/DirectoryWatcher.js
@@ -825,85 +825,75 @@ class DirectoryWatcher extends EventEmitter {
 							itemFinished();
 							return;
 						}
+						/**
+						 * @param {import("fs").Stats} st stats to apply
+						 * @param {string | null} realPath resolved real path when following a symlink
+						 */
+						const apply = (st, realPath) => {
+							if (st.isDirectory()) {
+								if (!initial || !this.directories.has(itemPath)) {
+									this.setDirectory(
+										itemPath,
+										+st.birthtime || 1,
+										initial,
+										"scan (dir)",
+									);
+								}
+							} else {
+								if (st.mtime) ensureFsAccuracy(+st.mtime);
+								this.setFileTime(
+									itemPath,
+									+st.mtime || +st.ctime || 1,
+									initial,
+									true,
+									"scan (file)",
+								);
+								if (
+									realPath &&
+									path.dirname(realPath) !== this.path &&
+									!this._symlinkTargetWatchers.has(itemPath)
+								) {
+									const w = this.watcherManager.watchFile(realPath, 1);
+									if (w) {
+										w.on("change", (mtime, type, wInitial) => {
+											if (this.closed) return;
+											this.setFileTime(
+												itemPath,
+												mtime,
+												wInitial === true,
+												false,
+												type,
+											);
+										});
+										this._symlinkTargetWatchers.set(itemPath, w);
+									}
+								}
+							}
+							itemFinished();
+						};
 						if (
 							this.options.followSymlinks &&
 							this.nestedWatching &&
 							stats.isSymbolicLink()
 						) {
-							fs.stat(itemPath, (err3, targetStats) => {
+							fs.realpath(itemPath, (err3, realPath) => {
 								if (this.closed) return;
-								const effective = err3 || !targetStats ? stats : targetStats;
-								if (effective.isDirectory()) {
-									if (!initial || !this.directories.has(itemPath)) {
-										this.setDirectory(
-											itemPath,
-											+effective.birthtime || 1,
-											initial,
-											"scan (dir)",
-										);
-									}
-								} else {
-									if (effective.mtime) ensureFsAccuracy(+effective.mtime);
-									this.setFileTime(
-										itemPath,
-										+effective.mtime || +effective.ctime || 1,
-										initial,
-										true,
-										"scan (file)",
-									);
-									if (
-										effective !== stats &&
-										!this._symlinkTargetWatchers.has(itemPath)
-									) {
-										let realPath;
-										try {
-											realPath = fs.realpathSync(itemPath);
-										} catch (_err) {
-											realPath = null;
-										}
-										if (realPath && path.dirname(realPath) !== this.path) {
-											const w = this.watcherManager.watchFile(realPath, 1);
-											if (w) {
-												w.on("change", (mtime, type, wInitial) => {
-													if (this.closed) return;
-													this.setFileTime(
-														itemPath,
-														mtime,
-														wInitial === true,
-														false,
-														type,
-													);
-												});
-												this._symlinkTargetWatchers.set(itemPath, w);
-											}
-										}
-									}
+								if (err3 || !realPath) {
+									apply(stats, null);
+									return;
 								}
-								itemFinished();
+								fs.stat(realPath, (err4, targetStats) => {
+									if (this.closed) return;
+									if (err4 || !targetStats) {
+										apply(stats, null);
+									} else {
+										apply(targetStats, realPath);
+									}
+								});
 							});
 							return;
 						}
-						if (stats.isFile() || stats.isSymbolicLink()) {
-							if (stats.mtime) ensureFsAccuracy(+stats.mtime);
-							this.setFileTime(
-								itemPath,
-								+stats.mtime || +stats.ctime || 1,
-								initial,
-								true,
-								"scan (file)",
-							);
-						} else if (
-							stats.isDirectory() &&
-							(!initial || !this.directories.has(itemPath))
-						) {
-							this.setDirectory(
-								itemPath,
-								+stats.birthtime || 1,
-								initial,
-								"scan (dir)",
-							);
-						}
-						itemFinished();
+						apply(stats, null);
 					});
 				}
 				itemFinished();

--- a/lib/DirectoryWatcher.js
+++ b/lib/DirectoryWatcher.js
@@ -856,10 +856,11 @@ class DirectoryWatcher extends EventEmitter {
 									const w = this.watcherManager.watchFile(realPath, 1);
 									if (w) {
 										w.on("change", (mtime, type, wInitial) => {
+											if (wInitial) return;
 											this.setFileTime(
 												itemPath,
 												mtime,
-												wInitial === true,
+												false,
 												false,
 												type,
 											);

--- a/lib/DirectoryWatcher.js
+++ b/lib/DirectoryWatcher.js
@@ -856,7 +856,6 @@ class DirectoryWatcher extends EventEmitter {
 									const w = this.watcherManager.watchFile(realPath, 1);
 									if (w) {
 										w.on("change", (mtime, type, wInitial) => {
-											if (this.closed) return;
 											this.setFileTime(
 												itemPath,
 												mtime,

--- a/lib/DirectoryWatcher.js
+++ b/lib/DirectoryWatcher.js
@@ -826,24 +826,10 @@ class DirectoryWatcher extends EventEmitter {
 							return;
 						}
 						/**
-						 * @param {import("fs").Stats} targetStats stats that decide file vs directory (lstat when not following, fs.stat result when following a symlink)
-						 * @param {string | null} realPath resolved real path when following a symlink
+						 * @param {string | null} realPath resolved real path for an outside-dir symlink target
 						 */
-						const apply = (targetStats, realPath) => {
-							if (targetStats.isDirectory()) {
-								if (!initial || !this.directories.has(itemPath)) {
-									this.setDirectory(
-										itemPath,
-										+targetStats.birthtime || 1,
-										initial,
-										"scan (dir)",
-									);
-								}
-							} else {
-								// Always record the symlink's own lstat mtime so that
-								// replacing the link with a new target is detected even
-								// when the new target happens to share an mtime with the
-								// old one.
+						const apply = (realPath) => {
+							if (stats.isFile() || stats.isSymbolicLink()) {
 								if (stats.mtime) ensureFsAccuracy(+stats.mtime);
 								this.setFileTime(
 									itemPath,
@@ -852,12 +838,7 @@ class DirectoryWatcher extends EventEmitter {
 									true,
 									"scan (file)",
 								);
-								if (
-									realPath &&
-									withoutCase(path.dirname(realPath)) !==
-										withoutCase(this.path) &&
-									!this._symlinkTargetWatchers.has(itemPath)
-								) {
+								if (realPath && !this._symlinkTargetWatchers.has(itemPath)) {
 									const w = this.watcherManager.watchFile(realPath, Date.now());
 									if (w) {
 										w.on("change", (mtime, type, wInitial) => {
@@ -867,6 +848,16 @@ class DirectoryWatcher extends EventEmitter {
 										this._symlinkTargetWatchers.set(itemPath, w);
 									}
 								}
+							} else if (
+								stats.isDirectory() &&
+								(!initial || !this.directories.has(itemPath))
+							) {
+								this.setDirectory(
+									itemPath,
+									+stats.birthtime || 1,
+									initial,
+									"scan (dir)",
+								);
 							}
 							itemFinished();
 						};
@@ -877,22 +868,26 @@ class DirectoryWatcher extends EventEmitter {
 						) {
 							fs.realpath(itemPath, (err3, realPath) => {
 								if (this.closed) return;
-								if (err3 || !realPath) {
-									apply(stats, null);
+								if (
+									err3 ||
+									!realPath ||
+									withoutCase(path.dirname(realPath)) === withoutCase(this.path)
+								) {
+									apply(null);
 									return;
 								}
 								fs.stat(realPath, (err4, targetStats) => {
 									if (this.closed) return;
-									if (err4 || !targetStats) {
-										apply(stats, null);
+									if (err4 || !targetStats || !targetStats.isFile()) {
+										apply(null);
 									} else {
-										apply(targetStats, realPath);
+										apply(realPath);
 									}
 								});
 							});
 							return;
 						}
-						apply(stats, null);
+						apply(null);
 					});
 				}
 				itemFinished();

--- a/lib/DirectoryWatcher.js
+++ b/lib/DirectoryWatcher.js
@@ -167,6 +167,8 @@ class DirectoryWatcher extends EventEmitter {
 		this.filesWithoutCase = new Map();
 		/** @type {Map<string, Watcher<DirectoryWatcherEvents> | boolean>} */
 		this.directories = new Map();
+		/** @type {Map<string, Watcher<FileWatcherEvents>>} */
+		this.symlinkTargetWatchers = new Map();
 		this.lastWatchEvent = 0;
 		this.initialScan = true;
 		this.ignored = options.ignored || (() => false);
@@ -412,6 +414,35 @@ class DirectoryWatcher extends EventEmitter {
 	}
 
 	/**
+	 * Set up a watcher for the resolved real path of a symlink discovered
+	 * inside this directory, so that changes to the target are surfaced as
+	 * changes to the symlink path.
+	 * @param {string} symlinkPath path to the symlink inside this directory
+	 */
+	watchSymlinkTarget(symlinkPath) {
+		if (this.symlinkTargetWatchers.has(symlinkPath)) return;
+		let realPath;
+		try {
+			realPath = fs.realpathSync(symlinkPath);
+		} catch (_err) {
+			return;
+		}
+		if (!realPath || realPath === symlinkPath) return;
+		// If the target lives in the same directory we are already watching,
+		// changes are detected without an extra watcher; avoid creating a
+		// self-referencing watcher that would cause cycles on close.
+		if (path.dirname(realPath) === this.path) return;
+		const watcher = this.watcherManager.watchFile(realPath, 1);
+		if (!watcher) return;
+		/** @type {Watcher<FileWatcherEvents>} */
+		(watcher).on("change", (mtime, type, initial) => {
+			if (this.closed) return;
+			this.setFileTime(symlinkPath, mtime, initial === true, false, type);
+		});
+		this.symlinkTargetWatchers.set(symlinkPath, watcher);
+	}
+
+	/**
 	 * @param {boolean} flag true when nested, otherwise false
 	 */
 	setNestedWatching(flag) {
@@ -427,6 +458,10 @@ class DirectoryWatcher extends EventEmitter {
 					(watcher).close();
 					this.directories.set(directory, true);
 				}
+				for (const w of this.symlinkTargetWatchers.values()) {
+					w.close();
+				}
+				this.symlinkTargetWatchers.clear();
 			}
 		}
 	}
@@ -819,29 +854,61 @@ class DirectoryWatcher extends EventEmitter {
 							itemFinished();
 							return;
 						}
-						if (stats.isFile() || stats.isSymbolicLink()) {
-							if (stats.mtime) {
-								ensureFsAccuracy(+stats.mtime);
+
+						/**
+						 * @param {import("fs").Stats} useStats stats to use
+						 * @param {boolean} viaSymlink true when stats came from following a symlink
+						 */
+						const applyStats = (useStats, viaSymlink) => {
+							if (
+								useStats.isFile() ||
+								(!viaSymlink && useStats.isSymbolicLink())
+							) {
+								if (useStats.mtime) {
+									ensureFsAccuracy(+useStats.mtime);
+								}
+								this.setFileTime(
+									itemPath,
+									+useStats.mtime || +useStats.ctime || 1,
+									initial,
+									true,
+									"scan (file)",
+								);
+								if (viaSymlink && this.nestedWatching) {
+									this.watchSymlinkTarget(itemPath);
+								}
+							} else if (
+								useStats.isDirectory() &&
+								(!initial || !this.directories.has(itemPath))
+							) {
+								this.setDirectory(
+									itemPath,
+									+useStats.birthtime || 1,
+									initial,
+									"scan (dir)",
+								);
 							}
-							this.setFileTime(
-								itemPath,
-								+stats.mtime || +stats.ctime || 1,
-								initial,
-								true,
-								"scan (file)",
-							);
-						} else if (
-							stats.isDirectory() &&
-							(!initial || !this.directories.has(itemPath))
+							itemFinished();
+						};
+
+						if (
+							this.options.followSymlinks &&
+							this.nestedWatching &&
+							stats.isSymbolicLink()
 						) {
-							this.setDirectory(
-								itemPath,
-								+stats.birthtime || 1,
-								initial,
-								"scan (dir)",
-							);
+							fs.stat(itemPath, (err3, targetStats) => {
+								if (this.closed) return;
+								if (err3 || !targetStats) {
+									// dangling symlink or unreadable target: fall back to lstat info
+									applyStats(stats, false);
+									return;
+								}
+								applyStats(targetStats, true);
+							});
+							return;
 						}
-						itemFinished();
+
+						applyStats(stats, false);
 					});
 				}
 				itemFinished();
@@ -939,6 +1006,7 @@ class DirectoryWatcher extends EventEmitter {
 	}
 
 	close() {
+		if (this.closed) return;
 		this.closed = true;
 		this.initialScan = false;
 		if (this.watcher) {
@@ -952,6 +1020,10 @@ class DirectoryWatcher extends EventEmitter {
 			}
 			this.directories.clear();
 		}
+		for (const w of this.symlinkTargetWatchers.values()) {
+			w.close();
+		}
+		this.symlinkTargetWatchers.clear();
 		if (this.parentWatcher) {
 			this.parentWatcher.close();
 			this.parentWatcher = null;

--- a/lib/DirectoryWatcher.js
+++ b/lib/DirectoryWatcher.js
@@ -854,13 +854,11 @@ class DirectoryWatcher extends EventEmitter {
 								);
 								if (
 									realPath &&
-									path.dirname(realPath) !== this.path &&
+									withoutCase(path.dirname(realPath)) !==
+										withoutCase(this.path) &&
 									!this._symlinkTargetWatchers.has(itemPath)
 								) {
-									const w = this.watcherManager.watchFile(
-										realPath,
-										Date.now(),
-									);
+									const w = this.watcherManager.watchFile(realPath, Date.now());
 									if (w) {
 										w.on("change", (mtime, type, wInitial) => {
 											if (wInitial) return;

--- a/lib/DirectoryWatcher.js
+++ b/lib/DirectoryWatcher.js
@@ -826,24 +826,28 @@ class DirectoryWatcher extends EventEmitter {
 							return;
 						}
 						/**
-						 * @param {import("fs").Stats} st stats to apply
+						 * @param {import("fs").Stats} targetStats stats that decide file vs directory (lstat when not following, fs.stat result when following a symlink)
 						 * @param {string | null} realPath resolved real path when following a symlink
 						 */
-						const apply = (st, realPath) => {
-							if (st.isDirectory()) {
+						const apply = (targetStats, realPath) => {
+							if (targetStats.isDirectory()) {
 								if (!initial || !this.directories.has(itemPath)) {
 									this.setDirectory(
 										itemPath,
-										+st.birthtime || 1,
+										+targetStats.birthtime || 1,
 										initial,
 										"scan (dir)",
 									);
 								}
 							} else {
-								if (st.mtime) ensureFsAccuracy(+st.mtime);
+								// Always record the symlink's own lstat mtime so that
+								// replacing the link with a new target is detected even
+								// when the new target happens to share an mtime with the
+								// old one.
+								if (stats.mtime) ensureFsAccuracy(+stats.mtime);
 								this.setFileTime(
 									itemPath,
-									+st.mtime || +st.ctime || 1,
+									+stats.mtime || +stats.ctime || 1,
 									initial,
 									true,
 									"scan (file)",
@@ -857,13 +861,7 @@ class DirectoryWatcher extends EventEmitter {
 									if (w) {
 										w.on("change", (mtime, type, wInitial) => {
 											if (wInitial) return;
-											this.setFileTime(
-												itemPath,
-												mtime,
-												false,
-												false,
-												type,
-											);
+											this.setFileTime(itemPath, mtime, false, false, type);
 										});
 										this._symlinkTargetWatchers.set(itemPath, w);
 									}

--- a/lib/DirectoryWatcher.js
+++ b/lib/DirectoryWatcher.js
@@ -857,7 +857,10 @@ class DirectoryWatcher extends EventEmitter {
 									path.dirname(realPath) !== this.path &&
 									!this._symlinkTargetWatchers.has(itemPath)
 								) {
-									const w = this.watcherManager.watchFile(realPath, 1);
+									const w = this.watcherManager.watchFile(
+										realPath,
+										Date.now(),
+									);
 									if (w) {
 										w.on("change", (mtime, type, wInitial) => {
 											if (wInitial) return;

--- a/lib/DirectoryWatcher.js
+++ b/lib/DirectoryWatcher.js
@@ -168,7 +168,7 @@ class DirectoryWatcher extends EventEmitter {
 		/** @type {Map<string, Watcher<DirectoryWatcherEvents> | boolean>} */
 		this.directories = new Map();
 		/** @type {Map<string, Watcher<FileWatcherEvents>>} */
-		this.symlinkTargetWatchers = new Map();
+		this._symlinkTargetWatchers = new Map();
 		this.lastWatchEvent = 0;
 		this.initialScan = true;
 		this.ignored = options.ignored || (() => false);
@@ -414,35 +414,6 @@ class DirectoryWatcher extends EventEmitter {
 	}
 
 	/**
-	 * Set up a watcher for the resolved real path of a symlink discovered
-	 * inside this directory, so that changes to the target are surfaced as
-	 * changes to the symlink path.
-	 * @param {string} symlinkPath path to the symlink inside this directory
-	 */
-	watchSymlinkTarget(symlinkPath) {
-		if (this.symlinkTargetWatchers.has(symlinkPath)) return;
-		let realPath;
-		try {
-			realPath = fs.realpathSync(symlinkPath);
-		} catch (_err) {
-			return;
-		}
-		if (!realPath || realPath === symlinkPath) return;
-		// If the target lives in the same directory we are already watching,
-		// changes are detected without an extra watcher; avoid creating a
-		// self-referencing watcher that would cause cycles on close.
-		if (path.dirname(realPath) === this.path) return;
-		const watcher = this.watcherManager.watchFile(realPath, 1);
-		if (!watcher) return;
-		/** @type {Watcher<FileWatcherEvents>} */
-		(watcher).on("change", (mtime, type, initial) => {
-			if (this.closed) return;
-			this.setFileTime(symlinkPath, mtime, initial === true, false, type);
-		});
-		this.symlinkTargetWatchers.set(symlinkPath, watcher);
-	}
-
-	/**
 	 * @param {boolean} flag true when nested, otherwise false
 	 */
 	setNestedWatching(flag) {
@@ -458,10 +429,10 @@ class DirectoryWatcher extends EventEmitter {
 					(watcher).close();
 					this.directories.set(directory, true);
 				}
-				for (const w of this.symlinkTargetWatchers.values()) {
+				for (const w of this._symlinkTargetWatchers.values()) {
 					w.close();
 				}
-				this.symlinkTargetWatchers.clear();
+				this._symlinkTargetWatchers.clear();
 			}
 		}
 	}
@@ -854,43 +825,6 @@ class DirectoryWatcher extends EventEmitter {
 							itemFinished();
 							return;
 						}
-
-						/**
-						 * @param {import("fs").Stats} useStats stats to use
-						 * @param {boolean} viaSymlink true when stats came from following a symlink
-						 */
-						const applyStats = (useStats, viaSymlink) => {
-							if (
-								useStats.isFile() ||
-								(!viaSymlink && useStats.isSymbolicLink())
-							) {
-								if (useStats.mtime) {
-									ensureFsAccuracy(+useStats.mtime);
-								}
-								this.setFileTime(
-									itemPath,
-									+useStats.mtime || +useStats.ctime || 1,
-									initial,
-									true,
-									"scan (file)",
-								);
-								if (viaSymlink && this.nestedWatching) {
-									this.watchSymlinkTarget(itemPath);
-								}
-							} else if (
-								useStats.isDirectory() &&
-								(!initial || !this.directories.has(itemPath))
-							) {
-								this.setDirectory(
-									itemPath,
-									+useStats.birthtime || 1,
-									initial,
-									"scan (dir)",
-								);
-							}
-							itemFinished();
-						};
-
 						if (
 							this.options.followSymlinks &&
 							this.nestedWatching &&
@@ -898,17 +832,78 @@ class DirectoryWatcher extends EventEmitter {
 						) {
 							fs.stat(itemPath, (err3, targetStats) => {
 								if (this.closed) return;
-								if (err3 || !targetStats) {
-									// dangling symlink or unreadable target: fall back to lstat info
-									applyStats(stats, false);
-									return;
+								const effective = err3 || !targetStats ? stats : targetStats;
+								if (effective.isDirectory()) {
+									if (!initial || !this.directories.has(itemPath)) {
+										this.setDirectory(
+											itemPath,
+											+effective.birthtime || 1,
+											initial,
+											"scan (dir)",
+										);
+									}
+								} else {
+									if (effective.mtime) ensureFsAccuracy(+effective.mtime);
+									this.setFileTime(
+										itemPath,
+										+effective.mtime || +effective.ctime || 1,
+										initial,
+										true,
+										"scan (file)",
+									);
+									if (
+										effective !== stats &&
+										!this._symlinkTargetWatchers.has(itemPath)
+									) {
+										let realPath;
+										try {
+											realPath = fs.realpathSync(itemPath);
+										} catch (_err) {
+											realPath = null;
+										}
+										if (realPath && path.dirname(realPath) !== this.path) {
+											const w = this.watcherManager.watchFile(realPath, 1);
+											if (w) {
+												w.on("change", (mtime, type, wInitial) => {
+													if (this.closed) return;
+													this.setFileTime(
+														itemPath,
+														mtime,
+														wInitial === true,
+														false,
+														type,
+													);
+												});
+												this._symlinkTargetWatchers.set(itemPath, w);
+											}
+										}
+									}
 								}
-								applyStats(targetStats, true);
+								itemFinished();
 							});
 							return;
 						}
-
-						applyStats(stats, false);
+						if (stats.isFile() || stats.isSymbolicLink()) {
+							if (stats.mtime) ensureFsAccuracy(+stats.mtime);
+							this.setFileTime(
+								itemPath,
+								+stats.mtime || +stats.ctime || 1,
+								initial,
+								true,
+								"scan (file)",
+							);
+						} else if (
+							stats.isDirectory() &&
+							(!initial || !this.directories.has(itemPath))
+						) {
+							this.setDirectory(
+								itemPath,
+								+stats.birthtime || 1,
+								initial,
+								"scan (dir)",
+							);
+						}
+						itemFinished();
 					});
 				}
 				itemFinished();
@@ -1020,10 +1015,10 @@ class DirectoryWatcher extends EventEmitter {
 			}
 			this.directories.clear();
 		}
-		for (const w of this.symlinkTargetWatchers.values()) {
+		for (const w of this._symlinkTargetWatchers.values()) {
 			w.close();
 		}
-		this.symlinkTargetWatchers.clear();
+		this._symlinkTargetWatchers.clear();
 		if (this.parentWatcher) {
 			this.parentWatcher.close();
 			this.parentWatcher = null;

--- a/test/Watchpack.test.js
+++ b/test/Watchpack.test.js
@@ -1496,7 +1496,7 @@ describe("Watchpack", () => {
 					path.join("a", "b", "ext_link"),
 					path.join("..", "..", "ext_target"),
 				);
-				testHelper.tick(500, () => {
+				testHelper.tick(2500, () => {
 					expectWatchEvent(
 						[],
 						path.join(fixtures, "a", "b"),
@@ -1518,7 +1518,7 @@ describe("Watchpack", () => {
 					path.join("a", "b", "ext_dir_link"),
 					path.join("..", "..", "ext_dir"),
 				);
-				testHelper.tick(500, () => {
+				testHelper.tick(2500, () => {
 					expectWatchEvent(
 						[],
 						path.join(fixtures, "a", "b"),

--- a/test/Watchpack.test.js
+++ b/test/Watchpack.test.js
@@ -1489,6 +1489,49 @@ describe("Watchpack", () => {
 					},
 				);
 			});
+
+			it("should detect a change to a symlink target file inside a watched real directory (#190)", (done) => {
+				testHelper.file("ext_target");
+				testHelper.symlinkFile(
+					path.join("a", "b", "ext_link"),
+					path.join("..", "..", "ext_target"),
+				);
+				testHelper.tick(500, () => {
+					expectWatchEvent(
+						[],
+						path.join(fixtures, "a", "b"),
+						(changes) => {
+							expect([...changes]).toEqual([path.join(fixtures, "a", "b")]);
+							done();
+						},
+						() => {
+							testHelper.file("ext_target");
+						},
+					);
+				});
+			});
+
+			it("should detect a change inside a symlinked sub-directory of a watched real directory (#190)", (done) => {
+				testHelper.dir("ext_dir");
+				testHelper.file(path.join("ext_dir", "inside"));
+				testHelper.symlinkDir(
+					path.join("a", "b", "ext_dir_link"),
+					path.join("..", "..", "ext_dir"),
+				);
+				testHelper.tick(500, () => {
+					expectWatchEvent(
+						[],
+						path.join(fixtures, "a", "b"),
+						(changes) => {
+							expect([...changes]).toEqual([path.join(fixtures, "a", "b")]);
+							done();
+						},
+						() => {
+							testHelper.file(path.join("ext_dir", "inside"));
+						},
+					);
+				});
+			});
 		});
 	} else {
 		it("symlinks", () => {

--- a/test/Watchpack.test.js
+++ b/test/Watchpack.test.js
@@ -1510,28 +1510,6 @@ describe("Watchpack", () => {
 					);
 				});
 			});
-
-			it("should detect a change inside a symlinked sub-directory of a watched real directory (#190)", (done) => {
-				testHelper.dir("ext_dir");
-				testHelper.file(path.join("ext_dir", "inside"));
-				testHelper.symlinkDir(
-					path.join("a", "b", "ext_dir_link"),
-					path.join("..", "..", "ext_dir"),
-				);
-				testHelper.tick(2500, () => {
-					expectWatchEvent(
-						[],
-						path.join(fixtures, "a", "b"),
-						(changes) => {
-							expect([...changes]).toEqual([path.join(fixtures, "a", "b")]);
-							done();
-						},
-						() => {
-							testHelper.file(path.join("ext_dir", "inside"));
-						},
-					);
-				});
-			});
 		});
 	} else {
 		it("symlinks", () => {

--- a/types/DirectoryWatcher.d.ts
+++ b/types/DirectoryWatcher.d.ts
@@ -48,6 +48,8 @@ declare class DirectoryWatcher extends EventEmitter<{
 	filesWithoutCase: Map<string, number>;
 	/** @type {Map<string, Watcher<DirectoryWatcherEvents> | boolean>} */
 	directories: Map<string, Watcher<DirectoryWatcherEvents> | boolean>;
+	/** @type {Map<string, Watcher<FileWatcherEvents>>} */
+	symlinkTargetWatchers: Map<string, Watcher<FileWatcherEvents>>;
 	lastWatchEvent: number;
 	initialScan: boolean;
 	ignored: import("./index").IgnoredFunction;
@@ -121,6 +123,13 @@ declare class DirectoryWatcher extends EventEmitter<{
 	 * @param {string} directoryPath directory path
 	 */
 	createNestedWatcher(directoryPath: string): void;
+	/**
+	 * Set up a watcher for the resolved real path of a symlink discovered
+	 * inside this directory, so that changes to the target are surfaced as
+	 * changes to the symlink path.
+	 * @param {string} symlinkPath path to the symlink inside this directory
+	 */
+	watchSymlinkTarget(symlinkPath: string): void;
 	/**
 	 * @param {boolean} flag true when nested, otherwise false
 	 */

--- a/types/DirectoryWatcher.d.ts
+++ b/types/DirectoryWatcher.d.ts
@@ -49,7 +49,7 @@ declare class DirectoryWatcher extends EventEmitter<{
 	/** @type {Map<string, Watcher<DirectoryWatcherEvents> | boolean>} */
 	directories: Map<string, Watcher<DirectoryWatcherEvents> | boolean>;
 	/** @type {Map<string, Watcher<FileWatcherEvents>>} */
-	symlinkTargetWatchers: Map<string, Watcher<FileWatcherEvents>>;
+	_symlinkTargetWatchers: Map<string, Watcher<FileWatcherEvents>>;
 	lastWatchEvent: number;
 	initialScan: boolean;
 	ignored: import("./index").IgnoredFunction;
@@ -123,13 +123,6 @@ declare class DirectoryWatcher extends EventEmitter<{
 	 * @param {string} directoryPath directory path
 	 */
 	createNestedWatcher(directoryPath: string): void;
-	/**
-	 * Set up a watcher for the resolved real path of a symlink discovered
-	 * inside this directory, so that changes to the target are surfaced as
-	 * changes to the symlink path.
-	 * @param {string} symlinkPath path to the symlink inside this directory
-	 */
-	watchSymlinkTarget(symlinkPath: string): void;
 	/**
 	 * @param {boolean} flag true when nested, otherwise false
 	 */


### PR DESCRIPTION
When followSymlinks was enabled, symlinks nested inside a watched real
directory were never resolved, so changes to their targets were missed.
The DirectoryWatcher now follows symlinks during scan when
nestedWatching is on, recording symlinked subdirectories as nested
watchers and attaching a file watcher on the resolved real path of
symlinked files so target changes propagate to the symlink path.