### PR TITLE
fix: also follow symlinked directories nested in watched real directories (#190)

### DIFF
--- a/lib/DirectoryWatcher.js
+++ b/lib/DirectoryWatcher.js
@@ -946,10 +946,23 @@ class DirectoryWatcher extends EventEmitter {
 								}
 								fs.stat(realPath, (err4, targetStats) => {
 									if (this.closed) return;
-									if (err4 || !targetStats || !targetStats.isFile()) {
+									if (err4 || !targetStats) {
 										apply(null);
-									} else {
+									} else if (targetStats.isFile()) {
 										apply(realPath);
+									} else if (targetStats.isDirectory()) {
+										// Treat a symlink whose target is a directory as a
+										// nested watched directory so files inside the target
+										// propagate change events to the symlink path.
+										this.setDirectory(
+											itemPath,
+											+targetStats.birthtime || +stats.birthtime || 1,
+											initial,
+											"scan (dir)",
+										);
+										itemFinished();
+									} else {
+										apply(null);
 									}
 								});
 							});

--- a/test/Watchpack.test.js
+++ b/test/Watchpack.test.js
@@ -1514,6 +1514,28 @@ describe("Watchpack", () => {
 					);
 				});
 			});
+
+			it("should detect a change inside a symlinked directory nested in a watched real directory (#190)", (done) => {
+				testHelper.dir("ext_dir");
+				testHelper.file(path.join("ext_dir", "inner"));
+				testHelper.symlinkDir(
+					path.join("a", "b", "ext_dir_link"),
+					path.join("..", "..", "ext_dir"),
+				);
+				testHelper.tick(2500, () => {
+					expectWatchEvent(
+						[],
+						path.join(fixtures, "a", "b"),
+						(changes) => {
+							expect([...changes]).toEqual([path.join(fixtures, "a", "b")]);
+							done();
+						},
+						() => {
+							testHelper.file(path.join("ext_dir", "inner"));
+						},
+					);
+				});
+			});
 		});
 	} else {
 		it("symlinks", () => {


### PR DESCRIPTION
PR #291 only handled the case where a symlink discovered inside a
watched real directory points to a file. When the symlink targeted a
directory the entry was still recorded via setFileTime, so no nested
DirectoryWatcher was created and changes inside the target were missed.

Now, when a discovered symlink resolves to a directory, setDirectory is
called for the symlink path so a nested watcher is created and its
contents are scanned and watched through the symlink.