### PR TITLE
fix: do not emit spurious initial-scan change events for items created within FS_ACCURACY of startTime (#295)

### DIFF
--- a/.changeset/fix-startime-fs-accuracy.md
+++ b/.changeset/fix-startime-fs-accuracy.md
@@ -1,5 +1,5 @@
 ---
-"watchpack": patch
+"watchpack": major
 ---
 
 fix: do not emit spurious initial-scan `change` events for files and
@@ -18,3 +18,10 @@ The `startTime` filter now compares against the raw `mtime`/`birthtime`
 instead, so only entries actually modified at or after `startTime`
 trigger a change event. The `change` event payload (and the existing
 `safeTime` semantics for consumers) are unchanged.
+
+**Breaking change:** consumers that relied on receiving initial-scan
+`change` events for files created within `FS_ACCURACY` of `startTime`
+(for example, to invalidate caches for files that were touched
+immediately before watching began) will no longer receive those events.
+The "outdated on attach" code path in `watch()` is unaffected and still
+uses `safeTime` semantics.

--- a/.changeset/fix-startime-fs-accuracy.md
+++ b/.changeset/fix-startime-fs-accuracy.md
@@ -1,5 +1,5 @@
 ---
-"watchpack": major
+"watchpack": patch
 ---
 
 fix: do not emit spurious initial-scan `change` events for files and
@@ -18,10 +18,3 @@ The `startTime` filter now compares against the raw `mtime`/`birthtime`
 instead, so only entries actually modified at or after `startTime`
 trigger a change event. The `change` event payload (and the existing
 `safeTime` semantics for consumers) are unchanged.
-
-**Breaking change:** consumers that relied on receiving initial-scan
-`change` events for files created within `FS_ACCURACY` of `startTime`
-(for example, to invalidate caches for files that were touched
-immediately before watching began) will no longer receive those events.
-The "outdated on attach" code path in `watch()` is unaffected and still
-uses `safeTime` semantics.

--- a/.changeset/fix-startime-fs-accuracy.md
+++ b/.changeset/fix-startime-fs-accuracy.md
@@ -1,0 +1,20 @@
+---
+"watchpack": patch
+---
+
+fix: do not emit spurious initial-scan `change` events for files and
+directories created within `FS_ACCURACY` (up to two seconds) of
+`startTime` (fixes #295).
+
+`DirectoryWatcher` previously compared an entry's `safeTime`
+(`Math.min(now, mtime) + FS_ACCURACY`) against the watcher's
+`startTime`. Because `safeTime` is intentionally inflated by
+`FS_ACCURACY` to account for filesystem timestamp granularity, every
+file or directory whose actual `mtime`/`birthtime` was up to
+`FS_ACCURACY` _before_ `startTime` was being flagged as changed during
+the initial scan.
+
+The `startTime` filter now compares against the raw `mtime`/`birthtime`
+instead, so only entries actually modified at or after `startTime`
+trigger a change event. The `change` event payload (and the existing
+`safeTime` semantics for consumers) are unchanged.

--- a/lib/DirectoryWatcher.js
+++ b/lib/DirectoryWatcher.js
@@ -135,7 +135,7 @@ function lstatWithRetry(target, watcher, callback, remaining = BUSY_RETRIES) {
 /**
  * @typedef {object} DirectoryWatcherEvents
  * @property {(type: EventType) => void} initial-missing initial missing event
- * @property {((file: string, mtime: number, type: EventType, initial: boolean) => void)} change change event
+ * @property {((file: string, mtime: number, type: EventType, initial: boolean, rawTimestamp?: number) => void)} change change event
  * @property {(type: EventType) => void} remove remove event
  * @property {() => void} closed closed event
  */
@@ -390,7 +390,7 @@ class DirectoryWatcher extends EventEmitter {
 			}
 
 			this.forEachWatcher(target, (w) => {
-				if (!initial || w.checkStartTime(safeTime, initial)) {
+				if (!initial || w.checkStartTime(mtime, initial)) {
 					w.emit("change", mtime, type);
 				}
 			});
@@ -398,8 +398,8 @@ class DirectoryWatcher extends EventEmitter {
 			this.forEachWatcher(target, (w) => w.emit("change", mtime, type));
 		}
 		this.forEachWatcher(this.path, (w) => {
-			if (!initial || w.checkStartTime(safeTime, initial)) {
-				w.emit("change", target, safeTime, type, initial);
+			if (!initial || w.checkStartTime(mtime, initial)) {
+				w.emit("change", target, safeTime, type, initial, mtime);
 			}
 		});
 	}
@@ -432,13 +432,13 @@ class DirectoryWatcher extends EventEmitter {
 				const safeTime = initial ? Math.min(now, birthtime) + FS_ACCURACY : now;
 
 				this.forEachWatcher(directoryPath, (w) => {
-					if (!initial || w.checkStartTime(safeTime, false)) {
+					if (!initial || w.checkStartTime(birthtime, false)) {
 						w.emit("change", birthtime, type);
 					}
 				});
 				this.forEachWatcher(this.path, (w) => {
-					if (!initial || w.checkStartTime(safeTime, initial)) {
-						w.emit("change", directoryPath, safeTime, type, initial);
+					if (!initial || w.checkStartTime(birthtime, initial)) {
+						w.emit("change", directoryPath, safeTime, type, initial, birthtime);
 					}
 				});
 			}
@@ -450,10 +450,16 @@ class DirectoryWatcher extends EventEmitter {
 	 */
 	createNestedWatcher(directoryPath) {
 		const watcher = this.watcherManager.watchDirectory(directoryPath, 1);
-		watcher.on("change", (target, mtime, type, initial) => {
+		watcher.on("change", (target, mtime, type, initial, rawTimestamp) => {
 			this.forEachWatcher(this.path, (w) => {
-				if (!initial || w.checkStartTime(mtime, initial)) {
-					w.emit("change", target, mtime, type, initial);
+				if (
+					!initial ||
+					w.checkStartTime(
+						rawTimestamp !== undefined ? rawTimestamp : mtime,
+						initial,
+					)
+				) {
+					w.emit("change", target, mtime, type, initial, rawTimestamp);
 				}
 			});
 		});

--- a/test/Watchpack.test.js
+++ b/test/Watchpack.test.js
@@ -1154,6 +1154,38 @@ describe("Watchpack", () => {
 		});
 	});
 
+	it("should not report changes in initial scan when start time is provided and items were created shortly before (#295)", (done) => {
+		const w = new WatchpackTest({
+			aggregateTimeout: 100,
+		});
+		w.on("aggregated", () => {
+			done(new Error("should not fire"));
+		});
+		testHelper.dir("dir");
+		testHelper.dir("dir/sub");
+		testHelper.file("dir/sub/nested");
+		testHelper.file("dir/file");
+		// Use a short tick (~100 ms) to mimic the real-world scenario where
+		// callers create files and then `await` something before calling
+		// `watch({ startTime: Date.now() })`. The previous behaviour added
+		// `FS_ACCURACY` (up to 2000 ms) to each entry's `safeTime` and
+		// compared the inflated value against `startTime`, which incorrectly
+		// flagged everything that was created within `FS_ACCURACY` before
+		// `startTime`.
+		testHelper.tick(() => {
+			w.watch({
+				directories: [path.join(fixtures, "dir")],
+				startTime: Date.now(),
+			});
+			testHelper.tick(2000, () => {
+				expect(true).toBe(true);
+				// no event fired
+				w.close();
+				done();
+			});
+		});
+	});
+
 	it("should not report changes to a folder watched as file when items are added", (done) => {
 		const w = new WatchpackTest({
 			aggregateTimeout: 100,

--- a/types/DirectoryWatcher.d.ts
+++ b/types/DirectoryWatcher.d.ts
@@ -209,7 +209,7 @@ import { EventEmitter } from "events";
 /**
  * @typedef {object} DirectoryWatcherEvents
  * @property {(type: EventType) => void} initial-missing initial missing event
- * @property {((file: string, mtime: number, type: EventType, initial: boolean) => void)} change change event
+ * @property {((file: string, mtime: number, type: EventType, initial: boolean, rawTimestamp?: number) => void)} change change event
  * @property {(type: EventType) => void} remove remove event
  * @property {() => void} closed closed event
  */
@@ -293,6 +293,7 @@ type DirectoryWatcherEvents = {
 		mtime: number,
 		type: EventType,
 		initial: boolean,
+		rawTimestamp?: number,
 	) => void;
 	/**
 	 * remove event


### PR DESCRIPTION
DirectoryWatcher previously compared an entry's `safeTime`
(`Math.min(now, mtime) + FS_ACCURACY`) against the watcher's
`startTime`. Because `safeTime` is intentionally inflated by
`FS_ACCURACY` to give callers an upper bound on possible modification
time, every file or directory whose actual mtime/birthtime was up to
`FS_ACCURACY` (initially 2000ms, typically 10ms after a single mtime
is observed) before `startTime` was being flagged as changed during
the initial scan.

The `startTime` filter now compares against the raw mtime/birthtime
instead, so only entries actually modified at or after `startTime`
trigger a change event during initial scan. The change event payload
still carries `safeTime` as before, and an additional optional
`rawTimestamp` argument is forwarded so nested directory watchers
can re-filter against the same raw timestamp.

The "outdated on attach" path in `watch()` continues to use
`safeTime` because its semantics are different: it represents "the
last time the file was known to be in a stable state", which is the
right value to compare against a newly attached watcher's startTime.

https://claude.ai/code/session_01CfqWhrftEvFkN5GiG82P67