### PR TITLE
fix: suppress stats errors for unstat-able paths in watch-event path

### DIFF
--- a/.changeset/silence-stats-errors-watch-events.md
+++ b/.changeset/silence-stats-errors-watch-events.md
@@ -1,0 +1,5 @@
+---
+"watchpack": patch
+---
+
+Suppress `Watchpack Error (stats)` logging for `EACCES`, `ENODEV`, and Windows `EINVAL` lstat errors in the watch-event path, matching the handling in the scan paths (e.g. `pagefile.sys` on a watched drive root with Node >= 22.17)

--- a/lib/DirectoryWatcher.js
+++ b/lib/DirectoryWatcher.js
@@ -615,11 +615,18 @@ class DirectoryWatcher extends EventEmitter {
 					// EBUSY happens when another process has the file locked (e.g.
 					// Windows AV scanner). lstatWithRetry already retried before
 					// giving up here.
+					// EACCES / ENODEV / EINVAL-on-Windows happen for entries that
+					// can never be stat'ed (protected system files like
+					// `pagefile.sys`, unreadable mounts, unmounted devices; see
+					// #187) and are treated as missing.
 					if (err) {
 						if (
 							err.code !== "ENOENT" &&
 							err.code !== "EPERM" &&
-							err.code !== "EBUSY"
+							err.code !== "EBUSY" &&
+							err.code !== "EACCES" &&
+							err.code !== "ENODEV" &&
+							!(err.code === "EINVAL" && IS_WIN)
 						) {
 							this.onStatsError(err);
 						} else if (

--- a/test/DirectoryWatcher.test.js
+++ b/test/DirectoryWatcher.test.js
@@ -360,6 +360,52 @@ describe("DirectoryWatcher", () => {
 				});
 			});
 		}
+
+		const watchEventCodes = IS_WIN
+			? ["EACCES", "ENODEV", "EINVAL"]
+			: ["EACCES", "ENODEV"];
+		for (const code of watchEventCodes) {
+			it(`does not log when lstat returns ${code} for a watch event`, (done) => {
+				testHelper.file("a");
+				testHelper.tick(1000, () => {
+					const directoryWatcher = getDirectoryWatcher(fixtures, EMPTY_OPTIONS);
+					const a = directoryWatcher.watch(path.join(fixtures, "a"));
+
+					testHelper.tick(500, () => {
+						const fs = require("graceful-fs");
+
+						const originalLstat = fs.lstat;
+						// eslint-disable-next-line jsdoc/reject-any-type
+						/** @type {any} */ (fs).lstat = (
+							/** @type {string} */ target,
+							/** @type {(err: NodeJS.ErrnoException | null) => void} */ cb,
+						) => {
+							if (target.endsWith(`${path.sep}a`)) {
+								process.nextTick(() => cb(makeErr(code)));
+								return;
+							}
+							originalLstat(target, cb);
+						};
+
+						const errorSpy = jest
+							.spyOn(console, "error")
+							.mockImplementation(() => {});
+						directoryWatcher.onWatchEvent("change", "a");
+						testHelper.tick(500, () => {
+							// eslint-disable-next-line jsdoc/reject-any-type
+							/** @type {any} */ (fs).lstat = originalLstat;
+							a.close();
+							const printed = errorSpy.mock.calls
+								.map((call) => String(call[0]))
+								.filter((msg) => msg.includes("Watchpack Error (stats)"));
+							errorSpy.mockRestore();
+							expect(printed).toEqual([]);
+							done();
+						});
+					});
+				});
+			});
+		}
 	});
 
 	describe("EBUSY retry handling (#223)", () => {


### PR DESCRIPTION
**Summary**

this ignores `EINVAL`, `EACCES` and `ENODEV` lstat errors on watch events, following up on #298

we noticed in this [in CI](https://github.com/nuxt/nuxt/actions/runs/29737171552/job/88355542839?pr=35740) (search for EINVAL in the logs)

this is a harmless situation and the fact that we already resolved #187 for initial scan suggests it's safe to do the same for watch events, and with the same motivation.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

yes

**Does this PR introduce a breaking change?**

no

**Use of AI**

I used AI to:

1) identify the cause of the log I was seeing in CI
2) identify the lines of code responsible for the error
3) search for similar issues or pull requests before opening this one